### PR TITLE
Add metadata validation and publication

### DIFF
--- a/mde-services/pom.xml
+++ b/mde-services/pom.xml
@@ -132,6 +132,15 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>de.terrestris</groupId>
+      <artifactId>bkg-testsuite-te</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.terrestris</groupId>
+      <artifactId>bkg-scripts</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/FileIdentifier.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/FileIdentifier.java
@@ -1,0 +1,9 @@
+package de.terrestris.mde.mde_backend.model.json;
+
+public interface FileIdentifier {
+
+  void setFileIdentifier(String identifier);
+
+  String getFileIdentifier();
+
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/JsonIsoMetadata.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/JsonIsoMetadata.java
@@ -22,7 +22,7 @@ import static com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @NoArgsConstructor(force = true)
 @AllArgsConstructor
-public class JsonIsoMetadata {
+public class JsonIsoMetadata implements FileIdentifier {
 
   public enum InspireTheme {
     AC,

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/Service.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/Service.java
@@ -17,7 +17,7 @@ import static com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @NoArgsConstructor(force = true)
 @AllArgsConstructor
-public class Service {
+public class Service implements FileIdentifier {
 
   public enum ServiceType {
     WFS,

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/DatasetIsoGenerator.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/DatasetIsoGenerator.java
@@ -404,18 +404,23 @@ public class DatasetIsoGenerator {
     writer.writeEndElement(); // report
   }
 
-  public void generateDatasetMetadata(JsonIsoMetadata metadata, String id, OutputStream out) throws IOException, XMLStreamException {
-    var writer = FACTORY.createXMLStreamWriter(out);
-    setNamespaceBindings(writer);
-    writer.writeStartDocument();
-    writer.writeStartElement(GMD, "MD_Metadata");
-    writeNamespaceBindings(writer);
+  /**
+   * Write metadata to a XMLStreamWriter.
+   * @param metadata the metadata object
+   * @param id       the metadata id
+   * @param writer   the writer, must have already written the MD_Metadata element and the namespace bindings etc.
+   * @throws IOException in case anything goes wrong
+   * @throws XMLStreamException in case anything goes wrong
+   */
+  public void generateDatasetMetadata(JsonIsoMetadata metadata, String id, XMLStreamWriter writer) throws IOException, XMLStreamException {
     writeFileIdentifier(writer, metadata.getFileIdentifier());
     writeLanguage(writer);
     writeCharacterSet(writer);
     writeHierarchyLevel(writer, dataset);
-    for (var contact : metadata.getContacts()) {
-      writeContact(writer, contact, "contact");
+    if (metadata.getContacts() != null) {
+      for (var contact : metadata.getContacts()) {
+        writeContact(writer, contact, "contact");
+      }
     }
     writeDateStamp(writer, metadata);
     writeMetadataInfo(writer);
@@ -423,6 +428,15 @@ public class DatasetIsoGenerator {
     writeIdentificationInfo(writer, metadata, id);
     writeDistributionInfo(writer, metadata);
     writeDataQualityInfo(writer, metadata, false);
+  }
+
+  public void generateDatasetMetadata(JsonIsoMetadata metadata, String id, OutputStream out) throws IOException, XMLStreamException {
+    var writer = FACTORY.createXMLStreamWriter(out);
+    setNamespaceBindings(writer);
+    writer.writeStartDocument();
+    writer.writeStartElement(GMD, "MD_Metadata");
+    generateDatasetMetadata(metadata, id, writer);
+    writeNamespaceBindings(writer);
     writer.writeEndElement(); // MD_Metadata
     writer.writeEndDocument();
     writer.close();

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/GeneratorUtils.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/GeneratorUtils.java
@@ -29,6 +29,9 @@ public class GeneratorUtils {
   }
 
   protected static void writeFileIdentifier(XMLStreamWriter writer, String fileIdentifier) throws XMLStreamException {
+    if (fileIdentifier == null) {
+      return;
+    }
     writer.writeStartElement(GMD, "fileIdentifier");
     writeSimpleElement(writer, GCO, "CharacterString", fileIdentifier);
     writer.writeEndElement();
@@ -104,6 +107,9 @@ public class GeneratorUtils {
   }
 
   protected static void writeDateStamp(XMLStreamWriter writer, JsonIsoMetadata metadata) throws XMLStreamException {
+    if (metadata.getDateTime() == null) {
+      return;
+    }
     writer.writeStartElement(GMD, "dateStamp");
     writeSimpleElement(writer, GCO, "DateTime", metadata.getDateTime().toString());
     writer.writeEndElement(); // dateStamp
@@ -139,7 +145,7 @@ public class GeneratorUtils {
     writer.writeStartElement(GMD, "date");
     writer.writeStartElement(GMD, "CI_Date");
     writer.writeStartElement(GMD, "date");
-    writeSimpleElement(writer, GCO, "Date", DateTimeFormatter.ISO_DATE.format(date.atOffset(ZoneOffset.UTC)));
+    writeSimpleElement(writer, GCO, "Date", DateTimeFormatter.ISO_DATE_TIME.format(date.atOffset(ZoneOffset.UTC)));
     writer.writeEndElement(); // Date
     writer.writeStartElement(GMD, "dateType");
     writeCodelistValue(writer, type);

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.fge.jsonpatch.JsonPatchException;
-import de.terrestris.mde.mde_backend.enumeration.MetadataProfile;
 import de.terrestris.mde.mde_backend.jpa.ClientMetadataRepository;
 import de.terrestris.mde.mde_backend.jpa.IsoMetadataRepository;
 import de.terrestris.mde.mde_backend.jpa.TechnicalMetadataRepository;
@@ -73,6 +72,8 @@ public class MetadataCollectionService {
         TechnicalMetadata technicalMetadata = new TechnicalMetadata(title, metadataId);
         IsoMetadata isoMetadata = new IsoMetadata(title, metadataId);
         isoMetadata.getData().setTitle(title);
+        isoMetadata.getData().setIdentifier(metadataId);
+        isoMetadata.getData().setFileIdentifier(null);
 
         clientMetadataRepository.save(clientMetadata);
         technicalMetadataRepository.save(technicalMetadata);
@@ -112,6 +113,8 @@ public class MetadataCollectionService {
         objectMapper.writeValueAsString(oTechnical.getData()),
         new TypeReference<JsonTechnicalMetadata>() {}
       );
+      clonedIsoData.setIdentifier(metadataId);
+      clonedIsoData.setFileIdentifier(null);
 
       isoMetadata.setData(clonedIsoData);
       clientMetadata.setData(clonedClientData);

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/PublicationService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/PublicationService.java
@@ -1,0 +1,158 @@
+package de.terrestris.mde.mde_backend.service;
+
+import com.nimbusds.jose.util.Base64;
+import de.terrestris.mde.mde_backend.model.json.FileIdentifier;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.log4j.Log4j2;
+import org.codehaus.stax2.XMLInputFactory2;
+import org.codehaus.stax2.XMLOutputFactory2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import java.io.*;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.ForkJoinPool;
+import java.util.function.Function;
+
+import static de.terrestris.utils.xml.MetadataNamespaceUtils.*;
+
+@Component
+@Log4j2
+public class PublicationService {
+
+  private static final XMLOutputFactory FACTORY = XMLOutputFactory2.newFactory();
+
+  private static final XMLInputFactory INPUT_FACTORY = XMLInputFactory2.newFactory();
+
+  private static final String CSW = "http://www.opengis.net/cat/csw/2.0.2";
+
+  @Value("${csw.server}")
+  private String cswServer;
+
+  @Value("${csw.user}")
+  private String cswUser;
+
+  @Value("${csw.password}")
+  private String cswPassword;
+
+  @Autowired
+  private DatasetIsoGenerator datasetIsoGenerator;
+
+  @Autowired
+  private ServiceIsoGenerator serviceIsoGenerator;
+
+  @Autowired
+  private IsoMetadataService metadataService;
+
+  @PostConstruct
+  public void completeCswUrl() {
+    if (!cswServer.endsWith("/")) {
+      cswServer = cswServer + "/";
+    }
+    cswServer = String.format("%ssrv/eng/csw-publication", cswServer);
+  }
+
+  private void sendTransaction(Function<XMLStreamWriter, Void> generator, boolean insert, FileIdentifier object) throws URISyntaxException, IOException, InterruptedException, XMLStreamException {
+    var publisher = HttpRequest.BodyPublishers.ofInputStream(() -> {
+      var in = new PipedInputStream();
+      try (var pool = ForkJoinPool.commonPool()) {
+        pool.submit(() -> {
+          var out = new BufferedOutputStream(new PipedOutputStream(in));
+          var writer = FACTORY.createXMLStreamWriter(out);
+          setNamespaceBindings(writer);
+          writer.setPrefix("csw", CSW);
+          writer.writeStartDocument();
+          writer.writeStartElement(CSW, "Transaction");
+          writeNamespaceBindings(writer);
+          writer.writeNamespace("csw", CSW);
+          writer.writeAttribute("service", "CSW");
+          writer.writeAttribute("version", "2.0.2");
+          writer.writeStartElement(CSW, insert ? "Insert" : "Update");
+          writer.writeStartElement(GMD, "MD_Metadata");
+          log.debug("Writing document");
+          generator.apply(writer);
+          log.debug("Wrote document");
+          writer.writeEndElement(); // MD_Metadata
+          writer.writeEndElement(); // Insert/Update
+          writer.writeEndElement(); // Transaction
+          writer.flush();
+          writer.close();
+          out.flush();
+          out.close();
+          return null;
+        });
+      }
+      return in;
+    });
+    try (var client = HttpClient.newHttpClient()) {
+      var builder = HttpRequest.newBuilder(new URI(cswServer));
+      var req = builder.POST(publisher);
+      var encoded = Base64.encode(String.format("%s:%s", cswUser, cswPassword)).toString();
+      req.header("Authorization", "Basic " + encoded)
+        .header("Content-Type", "application/xml");
+      log.debug("Sending request");
+      var response = client.send(req.build(), HttpResponse.BodyHandlers.ofInputStream());
+      log.debug("Sent request");
+      var reader = INPUT_FACTORY.createXMLStreamReader(response.body());
+      while (reader.hasNext()) {
+        reader.next();
+        if (!reader.isStartElement()) {
+          continue;
+        }
+        if (reader.getLocalName().equals("identifier")) {
+          var id = reader.getElementText();
+          log.debug("Extracted file identifier {}", id);
+          object.setFileIdentifier(id);
+        }
+      }
+    }
+  }
+
+  public void publishMetadata(String metadataId) throws XMLStreamException, IOException, URISyntaxException, InterruptedException {
+    var metadata = metadataService.findOneByMetadataId(metadataId);
+    if (metadata.isEmpty()) {
+      log.info("Metadata with ID {} is not available.", metadataId);
+      return;
+    }
+    var entity = metadata.get();
+    var data = entity.getData();
+    sendTransaction(writer -> {
+      try {
+        datasetIsoGenerator.generateDatasetMetadata(data, metadataId, writer);
+      } catch (IOException | XMLStreamException e) {
+        log.warn("Unable to generate dataset metadata: {}", e.getMessage());
+        log.trace("Stack trace:", e);
+      }
+      return null;
+    }, data.getFileIdentifier() == null, data);
+    if (data.getServices() != null) {
+      data.getServices().forEach(service -> {
+        try {
+          sendTransaction(writer -> {
+            try {
+              serviceIsoGenerator.generateServiceMetadata(data, service, writer);
+            } catch (IOException | XMLStreamException e) {
+              log.warn("Unable to generate service metadata: {}", e.getMessage());
+              log.trace("Stack trace:", e);
+            }
+            return null;
+          }, data.getFileIdentifier() == null, service);
+        } catch (URISyntaxException | IOException | InterruptedException | XMLStreamException e) {
+          log.warn("Unable to generate service metadata: {}", e.getMessage());
+          log.trace("Stack trace:", e);
+        }
+      });
+    }
+    metadataService.update(entity.getId(), entity);
+  }
+
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/ServiceIsoGenerator.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/ServiceIsoGenerator.java
@@ -31,12 +31,8 @@ public class ServiceIsoGenerator {
     writer.writeStartElement(SRV, "containsOperations");
     writer.writeStartElement(SRV, "SV_OperationMetadata");
     switch (service.getServiceType()) {
-      case WFS, WMS, WMTS -> {
-        writeOperation(writer, service, "GetCapabilities");
-      }
-      case ATOM -> {
-        writeOperation(writer, service, "Download");
-      }
+      case WFS, WMS, WMTS -> writeOperation(writer, service, "GetCapabilities");
+      case ATOM -> writeOperation(writer, service, "Download");
     }
     writer.writeEndElement(); // SV_CouplingType
     writer.writeEndElement(); // containsOperations
@@ -112,12 +108,8 @@ public class ServiceIsoGenerator {
     writer.writeStartElement(GCO, "LocalName");
     writer.writeAttribute("codeSpace", "http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType");
     switch (service.getServiceType()) {
-      case WFS, ATOM -> {
-        writer.writeCharacters("download");
-      }
-      case WMS, WMTS -> {
-        writer.writeCharacters("view");
-      }
+      case WFS, ATOM -> writer.writeCharacters("download");
+      case WMS, WMTS -> writer.writeCharacters("view");
     }
     writer.writeEndElement(); // LocalName
     writer.writeEndElement(); // serviceType
@@ -133,12 +125,8 @@ public class ServiceIsoGenerator {
         writeVersion(writer, "OGC:WMS 1.1.1");
         writeVersion(writer, "OGC:WMS 1.3.0");
       }
-      case ATOM -> {
-        writeVersion(writer, "predefined ATOM");
-      }
-      case WMTS -> {
-        writeVersion(writer, "OGC:WMTS 1.0.0");
-      }
+      case ATOM -> writeVersion(writer, "predefined ATOM");
+      case WMTS -> writeVersion(writer, "OGC:WMTS 1.0.0");
     }
     writeExtent(writer, metadata.getExtent(), SRV);
     writer.writeStartElement(SRV, "couplingType");
@@ -162,12 +150,15 @@ public class ServiceIsoGenerator {
     writer.writeEndElement(); // descriptiveKeywords
   }
 
-  public void generateServiceMetadata(JsonIsoMetadata metadata, Service service, OutputStream out) throws IOException, XMLStreamException {
-    var writer = FACTORY.createXMLStreamWriter(out);
-    setNamespaceBindings(writer);
-    writer.writeStartDocument();
-    writer.writeStartElement(GMD, "MD_Metadata");
-    writeNamespaceBindings(writer);
+  /**
+   * Write metadata to a XMLStreamWriter.
+   * @param metadata the metadata object
+   * @param service  the service object
+   * @param writer   the writer, must have already written the MD_Metadata element and the namespace bindings etc.
+   * @throws IOException in case anything goes wrong
+   * @throws XMLStreamException in case anything goes wrong
+   */
+  public void generateServiceMetadata(JsonIsoMetadata metadata, Service service, XMLStreamWriter writer) throws IOException, XMLStreamException {
     writeFileIdentifier(writer, service.getFileIdentifier());
     writeLanguage(writer);
     writeCharacterSet(writer);
@@ -181,6 +172,15 @@ public class ServiceIsoGenerator {
     writeServiceIdentification(writer, service, metadata);
     writeDistributionInfo(writer, metadata);
     writeDataQualityInfo(writer, metadata, true);
+  }
+
+  public void generateServiceMetadata(JsonIsoMetadata metadata, Service service, OutputStream out) throws IOException, XMLStreamException {
+    var writer = FACTORY.createXMLStreamWriter(out);
+    setNamespaceBindings(writer);
+    writer.writeStartDocument();
+    writer.writeStartElement(GMD, "MD_Metadata");
+    writeNamespaceBindings(writer);
+    generateServiceMetadata(metadata, service, writer);
     writer.writeEndElement(); // MD_Metadata
     writer.writeEndDocument();
     writer.close();

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/ValidatorService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/ValidatorService.java
@@ -1,0 +1,143 @@
+package de.terrestris.mde.mde_backend.service;
+
+import de.terrestris.bkgtestsuite.core.model.TestParameters;
+import de.terrestris.bkgtestsuite.core.model.TestResult;
+import de.terrestris.bkgtestsuite.core.spi.TestRunner;
+import de.terrestris.bkgtestsuite.te.TeTestRunner;
+import de.terrestris.mde.mde_backend.enumeration.MetadataProfile;
+import de.terrestris.mde.mde_backend.jpa.IsoMetadataRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static de.terrestris.bkgtestsuite.core.model.TestResult.MessageType.TEXT;
+import static de.terrestris.bkgtestsuite.core.model.TestResult.ResultStatus.*;
+
+@Component
+@Log4j2
+public class ValidatorService {
+
+  @Value("classpath:/bkg-scripts-metadata/src/scripts/config.json")
+  private Resource inspireConfig;
+
+  @Value("classpath:/bkg-scripts-metadata/src/config-iso/config.json")
+  private Resource isoConfig;
+
+  @Value("classpath:/bkg-scripts-metadata/src/**/*")
+  private List<Resource> metadataResources;
+
+  @Autowired
+  private IsoMetadataRepository isoMetadataRepository;
+
+  @Autowired
+  private IsoGenerator generator;
+
+  private TestRunner isoRunner;
+
+  private TestRunner inspireRunner;
+
+  private final List<Map<String, String>> inspireClasses = List.of(
+    Map.of("id", "ISO-Schemavalidierung"),
+      Map.of("id", "GDI-DE_INSPIRE_verpflichtend"),
+      Map.of("id", "GDI-DE_INSPIRE_konditional"),
+      Map.of("id", "GDI-DE_konditional"),
+      Map.of("id", "GDI-DE_optional"),
+      Map.of("id", "OpenData_konditional")
+  );
+
+  private final List<Map<String, String>> isoClasses = List.of(
+    Map.of("id", "ISO-Schemavalidierung"),
+    Map.of("id", "GDI-DE_verpflichtend"),
+    Map.of("id", "GDI-DE_konditional"),
+    Map.of("id", "GDI-DE_optional"),
+    Map.of("id", "OpenData_konditional")
+  );
+
+  @PostConstruct
+  public void loadIsoPackage() throws IOException {
+    var excluded = List.of("config.json", "main.ctl", "inspire_only.ctl");
+    var list = extractResources(metadataResources, file -> file.toString().contains("src/scripts"));
+    list = list.stream().filter(f -> !excluded.contains(f.getName())).collect(Collectors.toList());
+    isoRunner = new TeTestRunner(isoConfig.getInputStream(), list, new File("/tmp/bkg-scripts-metadata/src/resources"));
+  }
+
+  @PostConstruct
+  public void loadInspirePackage() throws IOException {
+    var excluded = List.of("config.json", "main2.ctl", "iso_only.ctl");
+    var list = extractResources(metadataResources, file -> file.toString().contains("src/scripts"));
+    list = list.stream().filter(f -> !excluded.contains(f.getName())).collect(Collectors.toList());
+    inspireRunner = new TeTestRunner(inspireConfig.getInputStream(), list, new File("/tmp/bkg-scripts-metadata/src/resources"));
+  }
+
+  private static List<File> extractResources(List<Resource> resources, Predicate<File> tester) throws IOException {
+    var list = new ArrayList<File>();
+    var tmp = new File("/tmp/");
+    for (Resource resource : resources) {
+      var path = ((ClassPathResource) resource).getPath();
+      var file = new File(tmp, path);
+      if (!file.getParentFile().exists() && !file.getParentFile().mkdirs()) {
+        log.warn("Unable to create script directory: {}", file.getParentFile());
+      }
+      IOUtils.copy(resource.getInputStream(), Files.newOutputStream(file.toPath()));
+      if (tester.test(file)) {
+        list.add(file);
+      }
+    }
+    return list;
+  }
+
+  private void extractErrors(TestResult result, List<String> errors) {
+    if (result.getStatus().equals(Failure) || result.getStatus().equals(TechnicalFailure) || result.getStatus().equals(InheritedFailure)) {
+      errors.addAll(result.getMessages().stream().filter(m -> m.getType().equals(TEXT)).map(TestResult.Message::getText).toList());
+    }
+    for (var sub : result.getSubresults()) {
+      extractErrors(sub, errors);
+    }
+  }
+
+  public List<String> validate(boolean inspire, Path file) {
+    var runner = inspire ? inspireRunner : isoRunner;
+    var classes = inspire ? inspireClasses : isoClasses;
+    var params = new TestParameters();
+    params.setParameters(Map.of("file", file.toString(), "conformanceClasses", classes));
+    var id = runner.runTest(params);
+    var result = runner.getTestResult(id);
+    runner.deleteTestResult(id);
+    var errors = new ArrayList<String>();
+    extractErrors(result, errors);
+    return errors;
+  }
+
+  public List<String> validateMetadata(String metadataId) throws XMLStreamException, IOException {
+    var metadata = isoMetadataRepository.findByMetadataId(metadataId);
+    if (metadata.isEmpty()) {
+      log.info("Metadata with ID {} is not available.", metadataId);
+      return null;
+    }
+    var data = metadata.get().getData();
+    var inspire = !data.getMetadataProfile().equals(MetadataProfile.ISO);
+    var files = generator.generateMetadata(metadataId);
+    var errors = new ArrayList<String>();
+    files.forEach(f -> errors.addAll(validate(inspire, f)));
+    FileUtils.deleteDirectory(files.getFirst().getParent().toFile());
+    return errors;
+  }
+
+}

--- a/mde-services/src/main/resources/application.properties
+++ b/mde-services/src/main/resources/application.properties
@@ -6,3 +6,4 @@ spring.jpa.open-in-view=false
 spring.jpa.show-sql=true
 spring.flyway.baseline-on-migrate=true
 spring.security.oauth2.resourceserver.jwt.issuer-uri=https://${KEYCLOAK_HOST}/auth/realms/${KEYCLOAK_REALM}
+csw.server=${CSW_SERVER}

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <spring-boot.version>3.4.0</spring-boot.version>
     <log4j.version>2.24.1</log4j.version>
     <hibernate-search.version>7.2.2.Final</hibernate-search.version>
+    <testsuite.version>1.1.18</testsuite.version>
   </properties>
 
   <repositories>
@@ -353,6 +354,16 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j2-impl</artifactId>
         <version>${log4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>de.terrestris</groupId>
+        <artifactId>bkg-testsuite-te</artifactId>
+        <version>${testsuite.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>de.terrestris</groupId>
+        <artifactId>bkg-scripts</artifactId>
+        <version>${testsuite.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Adds an endpoint that generates ISO metadata, runs the GDI-DE testsuite on it and returns the validation errors as a list of strings. Example:

```
curl -k https://localhost/api/metadata/iso/validate/1d1e7b5d-4d86-3ad7-8570-5245b55b6b33 -H "Authorization: Bearer <token>"
```

Also adds an endpoint that publishes the ISO metadata via CSW-T:

```
curl -k https://localhost/api/metadata/iso/publish/1d1e7b5d-4d86-3ad7-8570-5245b55b6b33 -H "Authorization: Bearer <token>"
```

Publication does not set the records public yet, this will be done in a followup. Insert/Update requests sometimes fail for some unknown reason with a null pointer in the GNOS, this needs to be further analyzed (but can be addressed in a followup as well).

@KaiVolland Please review.