### PR TITLE
Remove `title` BaseMetadata

### DIFF
--- a/mde-importer/src/main/java/de/terrestris/mde/mde_importer/importer/ImportService.java
+++ b/mde-importer/src/main/java/de/terrestris/mde/mde_importer/importer/ImportService.java
@@ -212,10 +212,7 @@ public class ImportService {
       json.setMetadataProfile(MetadataProfile.INSPIRE_IDENTIFIED);
     }
     skipToElement(reader, "Titel");
-    metadata.setTitle(reader.getElementText());
-    client.setTitle(metadata.getTitle());
-    technical.setTitle(metadata.getTitle());
-    json.setTitle(metadata.getTitle());
+    json.setTitle(reader.getElementText());
     skipToElement(reader, "fileIdentifier");
     skipToElement(reader, "CharacterString");
     json.setFileIdentifier(reader.getElementText());

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java
@@ -192,27 +192,6 @@ public class MetadataCollectionController {
     }
   }
 
-  @PostMapping("/{metadataId}/updateTitle")
-  public void updateTitle(@PathVariable("metadataId") String metadataId, @RequestBody String title) {
-    try {
-      service.updateTitle(metadataId, title);
-    } catch (Exception e) {
-      log.error("Error while updating title of metadata with id {}: \n {}", metadataId, e.getMessage());
-      log.trace("Full stack trace: ", e);
-
-      throw new ResponseStatusException(
-        HttpStatus.INTERNAL_SERVER_ERROR,
-        messageSource.getMessage(
-          "BASE_CONTROLLER.INTERNAL_SERVER_ERROR",
-          null,
-          LocaleContextHolder.getLocale()
-        ),
-        e
-      );
-    }
-  }
-
-
   @GetMapping("/{metadataId}/autokeywords")
   public ResponseEntity<List<String>> getAutomaticKeywords(@PathVariable("metadataId") String metadataId) {
     var maybeMetadata = service.findOneByMetadataId(metadataId);

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/BaseMetadata.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/BaseMetadata.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.Hibernate;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 
 import java.io.Serializable;
@@ -25,11 +24,6 @@ public abstract class BaseMetadata implements Serializable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     private BigInteger id;
-
-    @Column
-    @Setter
-    @FullTextField(analyzer = "standard")
-    private String title;
 
     @Column
     @Setter

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/ClientMetadata.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/ClientMetadata.java
@@ -23,9 +23,8 @@ public class ClientMetadata extends BaseMetadata {
   @ToString.Exclude
   private JsonClientMetadata data;
 
-  public ClientMetadata (String title, String metadataId) {
+  public ClientMetadata (String metadataId) {
     super();
-    setTitle(title);
     setMetadataId(metadataId);
     setData(new JsonClientMetadata());
   }

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/IsoMetadata.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/IsoMetadata.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.*;
+import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.Type;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -18,15 +19,17 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmb
 @Indexed
 public class IsoMetadata extends BaseMetadata {
 
+  @Formula("(data->>'title')")
+  private String title;
+
   @Column
   @Type(JsonBinaryType.class)
   @ToString.Exclude
   @IndexedEmbedded
   private JsonIsoMetadata data;
 
-  public IsoMetadata (String title, String metadataId) {
+  public IsoMetadata (String metadataId) {
     super();
-    setTitle(title);
     setMetadataId(metadataId);
     setData(new JsonIsoMetadata());
   }

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/TechnicalMetadata.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/TechnicalMetadata.java
@@ -23,9 +23,8 @@ public class TechnicalMetadata extends BaseMetadata {
   @ToString.Exclude
   private JsonTechnicalMetadata data;
 
-  public TechnicalMetadata (String title, String metadataId) {
+  public TechnicalMetadata (String metadataId) {
     super();
-    setTitle(title);
     setMetadataId(metadataId);
     setData(new JsonTechnicalMetadata());
   }

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/JsonIsoMetadata.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/JsonIsoMetadata.java
@@ -72,6 +72,7 @@ public class JsonIsoMetadata implements FileIdentifier {
 
   private String identifier;
 
+  @FullTextField
   private String title;
 
   @FullTextField

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/IsoMetadataService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/IsoMetadataService.java
@@ -24,7 +24,7 @@ public class IsoMetadataService extends BaseMetadataService<IsoMetadataRepositor
 
     return searchSession.search(IsoMetadata.class)
       .where(f -> f.simpleQueryString()
-        .fields("title", "data.description")
+        .fields("data.title", "data.description")
         // title is tokenized with standard analyzer so a wildcard prefix is not necessary
         .matching(searchTerm + "*")
       )

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
@@ -68,9 +68,9 @@ public class MetadataCollectionService {
     public String create(String title) {
         String metadataId = UUID.randomUUID().toString();
 
-        ClientMetadata clientMetadata = new ClientMetadata(title, metadataId);
-        TechnicalMetadata technicalMetadata = new TechnicalMetadata(title, metadataId);
-        IsoMetadata isoMetadata = new IsoMetadata(title, metadataId);
+        ClientMetadata clientMetadata = new ClientMetadata(metadataId);
+        TechnicalMetadata technicalMetadata = new TechnicalMetadata(metadataId);
+        IsoMetadata isoMetadata = new IsoMetadata(metadataId);
         isoMetadata.getData().setTitle(title);
         isoMetadata.getData().setIdentifier(metadataId);
         isoMetadata.getData().setFileIdentifier(null);
@@ -87,9 +87,9 @@ public class MetadataCollectionService {
     public String create(String title, String cloneMetadataId) throws IOException {
       String metadataId = UUID.randomUUID().toString();
 
-      ClientMetadata clientMetadata = new ClientMetadata(title, metadataId);
-      TechnicalMetadata technicalMetadata = new TechnicalMetadata(title, metadataId);
-      IsoMetadata isoMetadata = new IsoMetadata(title, metadataId);
+      ClientMetadata clientMetadata = new ClientMetadata(metadataId);
+      TechnicalMetadata technicalMetadata = new TechnicalMetadata(metadataId);
+      IsoMetadata isoMetadata = new IsoMetadata(metadataId);
 
       IsoMetadata oIso = isoMetadataRepository.findByMetadataId(cloneMetadataId)
         .orElseThrow(() -> new NoSuchElementException("IsoMetadata not found for metadataId: " + cloneMetadataId));
@@ -179,21 +179,6 @@ public class MetadataCollectionService {
         technicalMetadata.setData(updatedData);
 
         return technicalMetadataRepository.save(technicalMetadata);
-    }
-
-    @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#entity, 'UPDATE')")
-    @Transactional(isolation = Isolation.SERIALIZABLE)
-    public void updateTitle(String metadataId, String title) {
-      IsoMetadata oIso = isoMetadataRepository.findByMetadataId(metadataId)
-        .orElseThrow(() -> new NoSuchElementException("IsoMetadata not found for metadataId: " + metadataId));
-      ClientMetadata oClient = clientMetadataRepository.findByMetadataId(metadataId)
-        .orElseThrow(() -> new NoSuchElementException("ClientMetadata not found for metadataId: " + metadataId));
-      TechnicalMetadata oTechnical = technicalMetadataRepository.findByMetadataId(metadataId)
-        .orElseThrow(() -> new NoSuchElementException("TechnicalMetadata not found for metadataId: " + metadataId));
-
-      oIso.setTitle(title);
-      oClient.setTitle(title);
-      oTechnical.setTitle(title);
     }
 
 }

--- a/mde-services/src/main/resources/db/migration/V1.0.1__remove_title_from_metadata.sql
+++ b/mde-services/src/main/resources/db/migration/V1.0.1__remove_title_from_metadata.sql
@@ -1,0 +1,3 @@
+ALTER TABLE client_metadata DROP COLUMN IF EXISTS title;
+ALTER TABLE iso_metadata DROP COLUMN IF EXISTS title;
+ALTER TABLE technical_metadata DROP COLUMN IF EXISTS title;

--- a/mde-services/src/main/resources/db/migration/V2.0.0__remove_title_from_metadata.sql
+++ b/mde-services/src/main/resources/db/migration/V2.0.0__remove_title_from_metadata.sql
@@ -1,3 +1,0 @@
-ALTER TABLE client_metadata DROP COLUMN title;
-ALTER TABLE iso_metadata DROP COLUMN title;
-ALTER TABLE technical_metadata DROP COLUMN title;

--- a/mde-services/src/main/resources/db/migration/V2.0.0__remove_title_from_metadata.sql
+++ b/mde-services/src/main/resources/db/migration/V2.0.0__remove_title_from_metadata.sql
@@ -1,0 +1,3 @@
+ALTER TABLE client_metadata DROP COLUMN title;
+ALTER TABLE iso_metadata DROP COLUMN title;
+ALTER TABLE technical_metadata DROP COLUMN title;


### PR DESCRIPTION
This removes the `title` attribute from the BaseMetadata.

To allow searching the `title` attribute of the `JsonIsoMetadata` is now indexed.

Additionaly the `IsoMetadata` gets a virtual column with `@Formular` so that the pageble results from the `findAll` interface can still be sort alphabetically by the title.