### PR TITLE
Implement Filter

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java
@@ -3,10 +3,7 @@ package de.terrestris.mde.mde_backend.controller;
 import de.terrestris.mde.mde_backend.enumeration.MetadataType;
 import de.terrestris.mde.mde_backend.model.BaseMetadata;
 import de.terrestris.mde.mde_backend.model.MetadataCollection;
-import de.terrestris.mde.mde_backend.model.dto.MetadataCreationData;
-import de.terrestris.mde.mde_backend.model.dto.MetadataCreationResponse;
-import de.terrestris.mde.mde_backend.model.dto.MetadataJsonPatch;
-import de.terrestris.mde.mde_backend.model.dto.SearchConfig;
+import de.terrestris.mde.mde_backend.model.dto.*;
 import de.terrestris.mde.mde_backend.model.json.Comment;
 import de.terrestris.mde.mde_backend.service.DatasetIsoGenerator;
 import de.terrestris.mde.mde_backend.service.MetadataCollectionService;
@@ -350,12 +347,12 @@ public class MetadataCollectionController extends BaseMetadataController<Metadat
       description = "Internal Server Error: Something internal went wrong while updating the entity"
     )
   })
-  public List<MetadataCollection> search(@RequestBody SearchConfig searchConfig) {
+  public SearchResponse<MetadataCollection> search(@RequestBody SearchConfig searchConfig) {
 
     log.trace("Search request for MetadataCollection with searchConfig: {}", searchConfig);
     try {
       SearchResult<MetadataCollection> result = this.service.search(searchConfig);
-      return result.hits();
+      return new SearchResponse<MetadataCollection>(result.hits(), result.total().hitCount());
     } catch (Exception e) {
       log.error("Error while searching for MetadataCollection with searchConfig: {}", searchConfig, e);
 

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java
@@ -6,6 +6,7 @@ import de.terrestris.mde.mde_backend.model.MetadataCollection;
 import de.terrestris.mde.mde_backend.model.dto.MetadataCreationData;
 import de.terrestris.mde.mde_backend.model.dto.MetadataCreationResponse;
 import de.terrestris.mde.mde_backend.model.dto.MetadataJsonPatch;
+import de.terrestris.mde.mde_backend.model.dto.SearchConfig;
 import de.terrestris.mde.mde_backend.model.json.Comment;
 import de.terrestris.mde.mde_backend.service.DatasetIsoGenerator;
 import de.terrestris.mde.mde_backend.service.MetadataCollectionService;
@@ -247,6 +248,48 @@ public class MetadataCollectionController extends BaseMetadataController<Metadat
     }
   }
 
+  @DeleteMapping("/{metadataId}/addToTeam")
+  public ResponseEntity<Void> addToTeam(@PathVariable("metadataId") String metadataId, @RequestBody String userId) {
+    try {
+      service.addToTeam(metadataId, userId);
+      return new ResponseEntity<Void>(OK);
+    } catch (Exception e) {
+      log.error("Error while adding user to team of metadata with id {}: \n {}", metadataId, e.getMessage());
+      log.trace("Full stack trace: ", e);
+
+      throw new ResponseStatusException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        messageSource.getMessage(
+          "BASE_CONTROLLER.INTERNAL_SERVER_ERROR",
+          null,
+          LocaleContextHolder.getLocale()
+        ),
+        e
+      );
+    }
+  }
+
+  @PostMapping("/{metadataId}/removeFromTeam")
+  public ResponseEntity<Void> removeFromTeam(@PathVariable("metadataId") String metadataId, @RequestBody String userId) {
+    try {
+      service.removeFromTeam(metadataId, userId);
+      return new ResponseEntity<Void>(OK);
+    } catch (Exception e) {
+      log.error("Error while removing user from team of metadata with id {}: \n {}", metadataId, e.getMessage());
+      log.trace("Full stack trace: ", e);
+
+      throw new ResponseStatusException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        messageSource.getMessage(
+          "BASE_CONTROLLER.INTERNAL_SERVER_ERROR",
+          null,
+          LocaleContextHolder.getLocale()
+        ),
+        e
+      );
+    }
+  }
+
   @PostMapping("/{metadataId}/assignRole")
   public ResponseEntity<Void> assignRole(@PathVariable("metadataId") String metadataId, @RequestBody String role) {
     try {
@@ -289,7 +332,7 @@ public class MetadataCollectionController extends BaseMetadataController<Metadat
     }
   }
 
-  @GetMapping(
+  @PostMapping(
     path = "/search",
     produces = {
       "application/json"
@@ -307,14 +350,14 @@ public class MetadataCollectionController extends BaseMetadataController<Metadat
       description = "Internal Server Error: Something internal went wrong while updating the entity"
     )
   })
-  public List<MetadataCollection> search(@RequestParam String searchTerm, @RequestParam(required = false) Integer offset, @RequestParam(required = false) Integer limit) {
+  public List<MetadataCollection> search(@RequestBody SearchConfig searchConfig) {
 
-    log.trace("Search request for MetadataCollection with searchTerm: {}, offset: {}, limit: {}", searchTerm, offset, limit);
+    log.trace("Search request for MetadataCollection with searchConfig: {}", searchConfig);
     try {
-      SearchResult<MetadataCollection> result = this.service.search(searchTerm, offset, limit);
+      SearchResult<MetadataCollection> result = this.service.search(searchConfig);
       return result.hits();
     } catch (Exception e) {
-      log.error("Error while searching for MetadataCollection with searchTerm: {}, offset: {}, limit: {}", searchTerm, offset, limit, e);
+      log.error("Error while searching for MetadataCollection with searchConfig: {}", searchConfig, e);
 
       throw new ResponseStatusException(
         HttpStatus.INTERNAL_SERVER_ERROR,

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/MetadataCollection.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/MetadataCollection.java
@@ -9,9 +9,12 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.Type;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 
-import java.util.List;
+import java.util.Set;
 
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
@@ -29,10 +32,19 @@ public class MetadataCollection extends BaseMetadata {
 
   @Column
   @Setter
-  private List<String> responsibleUserIds;
+  @FullTextField
+  @KeywordField(name = "team_member_sort", sortable = Sortable.YES)
+  private Set<String> teamMemberIds;
 
   @Column
   @Setter
+  @KeywordField
+  private String assignedUserId;
+
+  @Column
+  @Setter
+  @KeywordField
+  @Enumerated(EnumType.STRING)
   private Role responsibleRole;
 
   @Column

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/SearchConfig.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/SearchConfig.java
@@ -1,0 +1,27 @@
+package de.terrestris.mde.mde_backend.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import de.terrestris.mde.mde_backend.enumeration.Role;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SearchConfig {
+
+    private String searchTerm;
+
+    private Boolean isAssignedToMe;
+
+    private Boolean isTeamMember;
+
+    private Boolean isValid;
+
+    private List<Role> assignedRoles;
+
+    private Integer offset = 0;
+
+    private Integer limit = 10;
+
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/SearchResponse.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/SearchResponse.java
@@ -1,0 +1,8 @@
+package de.terrestris.mde.mde_backend.model.dto;
+
+import java.util.List;
+
+public record SearchResponse<T>(
+  List<T> results,
+  long totalHitCount
+) { }

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/JsonIsoMetadata.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/JsonIsoMetadata.java
@@ -8,7 +8,9 @@ import de.terrestris.mde.mde_backend.model.json.codelists.MD_MaintenanceFrequenc
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 
 import java.math.BigInteger;
 import java.time.Instant;
@@ -72,10 +74,10 @@ public class JsonIsoMetadata implements FileIdentifier {
 
   private String identifier;
 
-  @FullTextField
+  @FullTextField()
+  @GenericField(name = "title_sort", sortable = Sortable.YES)
   private String title;
 
-  @FullTextField
   private String description;
 
   private List<Service> services;
@@ -95,6 +97,7 @@ public class JsonIsoMetadata implements FileIdentifier {
   @JsonFormat(shape = STRING)
   private Instant published;
 
+  @GenericField(name = "modified_sort", sortable = Sortable.YES)
   @JsonFormat(shape = STRING)
   private Instant modified;
 
@@ -128,6 +131,7 @@ public class JsonIsoMetadata implements FileIdentifier {
 
   private String lineage;
 
+  @GenericField
   private boolean valid;
 
   private String topicCategory;

--- a/mde-services/src/main/resources/db/migration/V2.0.1__refactor_assinged_columns.sql
+++ b/mde-services/src/main/resources/db/migration/V2.0.1__refactor_assinged_columns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE metadata_collection ADD COLUMN assigned_user_id TEXT;
+ALTER TABLE metadata_collection RENAME COLUMN responsible_user_ids TO team_member_ids;


### PR DESCRIPTION
This extends the search interface to support multiple filters.

The interface now is a POST endpoint that receives a SearchConfig to handle different filtering approaches. It responds with a SearchRespone entity that includes the totalHits to allow pagination for SearchResults.

This PR also includes a migration that adds and updates columns of the `MetadataCollection` and corresponding interfaces.