### PR TITLE
Replace lucene search with hibernate query and add sorting

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java
@@ -13,10 +13,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.extern.log4j.Log4j2;
-import org.hibernate.search.engine.search.query.SearchResult;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -41,6 +44,7 @@ public class MetadataCollectionController extends BaseMetadataController<Metadat
 
   @Autowired
   protected MessageSource messageSource;
+
 
   @GetMapping("/{metadataId}")
   @ResponseStatus(HttpStatus.OK)
@@ -330,7 +334,7 @@ public class MetadataCollectionController extends BaseMetadataController<Metadat
   }
 
   @PostMapping(
-    path = "/search",
+    path = "/query",
     produces = {
       "application/json"
     }
@@ -340,21 +344,19 @@ public class MetadataCollectionController extends BaseMetadataController<Metadat
   @ApiResponses(value = {
     @ApiResponse(
       responseCode = "200",
-      description = "Ok: The entity was successfully updated"
+      description = "Ok: MetadataCollections were successfully queried"
     ),
     @ApiResponse(
       responseCode = "500",
-      description = "Internal Server Error: Something internal went wrong while updating the entity"
+      description = "Internal Server Error: Something internal went wrong while querying MetadataCollections"
     )
   })
-  public SearchResponse<MetadataCollection> search(@RequestBody SearchConfig searchConfig) {
-
-    log.trace("Search request for MetadataCollection with searchConfig: {}", searchConfig);
+  public Page<MetadataCollection> query(@RequestBody QueryConfig queryConfig, @PageableDefault(Integer.MAX_VALUE) @ParameterObject Pageable pageable) {
+    log.trace("Query MetadataCollections with queryConfig: {}", queryConfig);
     try {
-      SearchResult<MetadataCollection> result = this.service.search(searchConfig);
-      return new SearchResponse<MetadataCollection>(result.hits(), result.total().hitCount());
+      return this.service.query(queryConfig, pageable);
     } catch (Exception e) {
-      log.error("Error while searching for MetadataCollection with searchConfig: {}", searchConfig, e);
+      log.error("Error while querying MetadataCollection with queryConfig: {}", queryConfig, e);
 
       throw new ResponseStatusException(
         HttpStatus.INTERNAL_SERVER_ERROR,

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/MetadataCollection.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/MetadataCollection.java
@@ -30,6 +30,9 @@ public class MetadataCollection extends BaseMetadata {
   @Formula("(iso_metadata->>'title')")
   private String title;
 
+  @Formula("(iso_metadata->>'valid')::boolean")
+  private Boolean valid;
+
   @Column
   @Setter
   @FullTextField

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/QueryConfig.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/QueryConfig.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class SearchConfig {
+public class QueryConfig {
 
     private String searchTerm;
 
@@ -19,9 +19,5 @@ public class SearchConfig {
     private Boolean isValid;
 
     private List<Role> assignedRoles;
-
-    private Integer offset = 0;
-
-    private Integer limit = 10;
 
 }

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/SearchResponse.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/SearchResponse.java
@@ -1,8 +1,0 @@
-package de.terrestris.mde.mde_backend.model.dto;
-
-import java.util.List;
-
-public record SearchResponse<T>(
-  List<T> results,
-  long totalHitCount
-) { }

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/specification/MetadataCollectionSpecification.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/specification/MetadataCollectionSpecification.java
@@ -1,0 +1,70 @@
+package de.terrestris.mde.mde_backend.specification;
+
+import de.terrestris.mde.mde_backend.model.MetadataCollection;
+import de.terrestris.mde.mde_backend.model.dto.QueryConfig;
+import jakarta.persistence.criteria.*;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MetadataCollectionSpecification {
+
+  public static Specification<MetadataCollection> searchMetadata(QueryConfig config, String myKeycloakId) {
+    return (Root<MetadataCollection> root, CriteriaQuery<?> query, CriteriaBuilder cb) -> {
+
+      List<Predicate> predicates = new ArrayList<>();
+
+      // Text-Filter
+      if (config.getSearchTerm() != null && !config.getSearchTerm().isEmpty()) {
+        predicates.add(cb.like(
+          cb.lower(root.get("title")),
+          "%" + config.getSearchTerm().toLowerCase() + "%"
+        ));
+      }
+
+      // Valid-Filter
+      if (config.getIsValid() != null) {
+        predicates.add(cb.equal(root.get("valid"), config.getIsValid()));
+      }
+
+      // Assigned-Filter
+      if (config.getIsAssignedToMe() != null) {
+        if (config.getIsAssignedToMe()) {
+          predicates.add(cb.equal(root.get("assignedUserId"), myKeycloakId));
+        } else {
+          predicates.add(cb.notEqual(root.get("assignedUserId"), myKeycloakId));
+        }
+      }
+
+      // Team-Member-Filter (reused in sortPriority)
+      Expression<Boolean> isTeamMember = cb.isNotNull(cb.function(
+        "array_position",
+        Integer.class,
+        root.get("teamMemberIds"),
+        cb.literal(myKeycloakId)
+      ));
+      if (config.getIsTeamMember() != null) {
+        if (config.getIsTeamMember()) {
+          predicates.add(cb.isTrue(isTeamMember));
+        } else {
+          predicates.add(cb.isFalse(isTeamMember));
+        }
+      }
+
+      // Role-Filter
+      if (config.getAssignedRoles() != null && !config.getAssignedRoles().isEmpty()) {
+        predicates.add(root.get("responsibleRole").in(config.getAssignedRoles()));
+      }
+
+      Expression<Object> sortPriority = cb.selectCase()
+        .when(cb.equal(root.get("assignedUserId"), myKeycloakId), 0)
+        .when(cb.isTrue(isTeamMember), 1)
+        .otherwise(2);
+
+      query.orderBy(cb.asc(sortPriority), cb.asc(root.get("title")));
+
+      return cb.and(predicates.toArray(new Predicate[0]));
+    };
+  }
+}


### PR DESCRIPTION
This replaces the `/search` interface with the `/query` interface.

Hibernate criteria queries are now used instead of lucene search. Performance is still very good but working with the specification has more configuration options.