### PR TITLE
Add downloads field to Service

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/DownloadInfo.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/DownloadInfo.java
@@ -1,0 +1,27 @@
+package de.terrestris.mde.mde_backend.model.json;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigInteger;
+
+@Data
+@JsonDeserialize(as = DownloadInfo.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@NoArgsConstructor(force = true)
+@AllArgsConstructor
+public class DownloadInfo {
+
+  private String title;
+
+  // TODO: This should be an enum
+  private String type;
+
+  private String href;
+
+  private BigInteger fileSize;
+
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/Service.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/Service.java
@@ -63,4 +63,7 @@ public class Service implements FileIdentifier {
 
   private List<ColumnInfo> columns;
 
+  // TODO: update importer according to excel sheet
+  private List<DownloadInfo> downloads;
+
 }


### PR DESCRIPTION
This pull request introduces a new class and updates an existing class to include a list of `DownloadInfo` objects. The most important changes are:

### New Class Addition:
* [`mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/DownloadInfo.java`](diffhunk://#diff-c13c74cfaee37c3caba8e1112626e208a3a5c8989d45bd1acc51bf127307e302R1-R27): Added a new class `DownloadInfo` with fields `title`, `type`, `href`, and `fileSize`. This class includes annotations for JSON deserialization and inclusion, as well as Lombok annotations for boilerplate code reduction.

### Existing Class Update:
* [`mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/Service.java`](diffhunk://#diff-f169b2b8a9a2b54c2fb11199972bb7ea22bdebdd75b1546df74d8bfc585cac2aR66-R68): Added a new field `downloads` to the `ServiceType` enum to hold a list of `DownloadInfo` objects.