### PR TITLE
Add INSPIRE validator test classes

### DIFF
--- a/mde-importer/src/main/java/de/terrestris/mde/mde_importer/importer/ImportService.java
+++ b/mde-importer/src/main/java/de/terrestris/mde/mde_importer/importer/ImportService.java
@@ -247,15 +247,12 @@ public class ImportService {
     skipToElement(reader, "MD_DataIdentification");
     metadataCollection.setMetadataId(reader.getAttributeValue(null, "uuid"));
     var isoMetadata = metadataCollection.getIsoMetadata();
+    isoMetadata.setIdentifier(metadataCollection.getMetadataId());
     isoMetadata.setPointsOfContact(new ArrayList<>());
     while (reader.hasNext() && !(reader.isEndElement() && reader.getLocalName().equals("MD_Metadata"))) {
       reader.next();
       if (!reader.isStartElement()) {
         continue;
-      }
-      if (reader.isStartElement() && reader.getLocalName().equals("identifier")) {
-        skipToElement(reader, "CharacterString");
-        isoMetadata.setIdentifier(reader.getElementText());
       }
       if (reader.isStartElement() && reader.getLocalName().equals("abstract")) {
         skipToElement(reader, "CharacterString");
@@ -762,6 +759,9 @@ public class ImportService {
         break;
       case "Title":
         service.setTitle(reader.getElementText());
+        break;
+      case "CapabilitiesUrl":
+        service.setCapabilitiesUrl(reader.getElementText());
         break;
       case "Kurzbeschreibung":
         service.setShortDescription(reader.getElementText());

--- a/mde-services/pom.xml
+++ b/mde-services/pom.xml
@@ -150,6 +150,10 @@
     </dependency>
     <dependency>
       <groupId>de.terrestris</groupId>
+      <artifactId>bkg-testsuite-etf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.terrestris</groupId>
       <artifactId>bkg-scripts</artifactId>
     </dependency>
   </dependencies>

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/Service.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/Service.java
@@ -42,6 +42,8 @@ public class Service implements FileIdentifier {
 
   private String url;
 
+  private String capabilitiesUrl;
+
   private List<ServiceDescription> serviceDescriptions;
 
   private LegendImage legendImage;

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/codelists/MD_GeometricObjectTypeCode.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/codelists/MD_GeometricObjectTypeCode.java
@@ -1,0 +1,10 @@
+package de.terrestris.mde.mde_backend.model.json.codelists;
+
+public enum MD_GeometricObjectTypeCode {
+  complex,
+  composite,
+  curve,
+  point,
+  solid,
+  surface
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/codelists/MD_SpatialRepresentationTypeCode.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/codelists/MD_SpatialRepresentationTypeCode.java
@@ -1,0 +1,10 @@
+package de.terrestris.mde.mde_backend.model.json.codelists;
+
+public enum MD_SpatialRepresentationTypeCode {
+  vector,
+  grid,
+  textTable,
+  tin,
+  stereoModel,
+  video
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/GeneratorUtils.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/GeneratorUtils.java
@@ -13,6 +13,7 @@ import java.time.format.DateTimeFormatter;
 
 import static de.terrestris.mde.mde_backend.model.json.codelists.CI_OnLineFunctionCode.information;
 import static de.terrestris.mde.mde_backend.model.json.codelists.MD_CharacterSetCode.utf8;
+import static de.terrestris.mde.mde_backend.model.json.codelists.MD_GeometricObjectTypeCode.complex;
 import static de.terrestris.mde.mde_backend.service.IsoGenerator.replaceValues;
 import static de.terrestris.utils.xml.MetadataNamespaceUtils.*;
 import static de.terrestris.utils.xml.XmlUtils.writeSimpleElement;
@@ -115,13 +116,28 @@ public class GeneratorUtils {
     writer.writeEndElement(); // dateStamp
   }
 
-  protected static void writeMetadataInfo(XMLStreamWriter writer) throws XMLStreamException {
+  protected static void writeMetadataInfo(XMLStreamWriter writer, boolean inspire) throws XMLStreamException {
     writer.writeStartElement(GMD, "metadataStandardName");
     writeSimpleElement(writer, GCO, "CharacterString", "ISO 19115/19119 ? BE");
     writer.writeEndElement(); // metadataStandardName
     writer.writeStartElement(GMD, "metadataStandardVersion");
     writeSimpleElement(writer, GCO, "CharacterString", "1.0.0");
     writer.writeEndElement(); // metadataStandardVersion
+    if (!inspire) {
+      return;
+    }
+    // TODO this is hardcoded for now, because details are not prompted in the ui
+    writer.writeStartElement(GMD, "spatialRepresentationInfo");
+    writer.writeStartElement(GMD, "MD_VectorSpatialRepresentation");
+    writer.writeStartElement(GMD, "geometricObjects");
+    writer.writeStartElement(GMD, "MD_GeometricObjects");
+    writer.writeStartElement(GMD, "geometricObjectType");
+    writeCodelistValue(writer, complex);
+    writer.writeEndElement(); // geometricObjectType
+    writer.writeEndElement(); // MD_GeometricObjects
+    writer.writeEndElement(); // geometricObjects
+    writer.writeEndElement(); // MD_VectorSpatialRepresentation
+    writer.writeEndElement(); // spatialRepresentationInfo
   }
 
   protected static void writeCrs(XMLStreamWriter writer, JsonIsoMetadata metadata) throws XMLStreamException {
@@ -145,7 +161,7 @@ public class GeneratorUtils {
     writer.writeStartElement(GMD, "date");
     writer.writeStartElement(GMD, "CI_Date");
     writer.writeStartElement(GMD, "date");
-    writeSimpleElement(writer, GCO, "Date", DateTimeFormatter.ISO_DATE_TIME.format(date.atOffset(ZoneOffset.UTC)));
+    writeSimpleElement(writer, GCO, "Date", DateTimeFormatter.ISO_DATE.format(date.atOffset(ZoneOffset.UTC).toLocalDate()));
     writer.writeEndElement(); // Date
     writer.writeStartElement(GMD, "dateType");
     writeCodelistValue(writer, type);

--- a/mde-services/src/main/resources/config-dataset.json
+++ b/mde-services/src/main/resources/config-dataset.json
@@ -1,0 +1,18 @@
+{
+  "url": "https://inspire.ec.europa.eu/validator/",
+  "sort": "20101",
+  "testClassName": {
+    "de": "INSPIRE Metadata TG 2.0 - data sets and data sets series",
+    "en": "INSPIRE Metadata TG 2.0 - data sets and data sets series"
+  },
+  "helpTextDe": "Hier können Sie ggf. weitere optionale Konformitätsklassen hinzuwählen, bspw. für die Prüfung der Konformität zu bestimmten Applikationsschemata oder spezifischen Metadaten-Anforderungen.",
+  "helpTextEn": "If necessary, you can add further optional conformance classes here, e.g. for checking conformance to certain application schemas or specific metadata requirements.",
+  "conformanceClasses": {
+    "EID59692c11-df86-49ad-be7f-94a1e1ddd8da": true,
+    "EIDe4a95862-9cc9-436b-9fdd-a0115d342350": true,
+    "EID2be1480a-fe42-40b2-9420-eb0e69385c80": true,
+    "EID0b86f7a3-2947-4841-823d-6a00d8e06d70": true,
+    "EID1067d6b2-3bb1-4e71-8ce1-a744c9bd5a3b": false,
+    "EID7cceba68-e575-4429-9959-1b6b3d201b6d": false
+  }
+}

--- a/mde-services/src/main/resources/config-networkservices.json
+++ b/mde-services/src/main/resources/config-networkservices.json
@@ -1,0 +1,15 @@
+{
+  "url": "https://inspire.ec.europa.eu/validator/",
+  "sort": "20102",
+  "testClassName": {
+    "de": "INSPIRE Metadata TG 2.0 - network services",
+    "en": "INSPIRE Metadata TG 2.0 - network services"
+  },
+  "helpTextDe": "Hier können Sie ggf. weitere optionale Konformitätsklassen hinzuwählen, bspw. für die Prüfung der Konformität zu bestimmten Applikationsschemata oder spezifischen Metadaten-Anforderungen.",
+  "helpTextEn": "If necessary, you can add further optional conformance classes here, e.g. for checking conformance to certain application schemas or specific metadata requirements.",
+  "conformanceClasses": {
+    "EID59692c11-df86-49ad-be7f-94a1e1ddd8da": true,
+    "EID8f869e23-c9e9-4e86-8dca-be30ff421229": true,
+    "EID606587df-65a8-4b7b-9eee-e0d94daaa42a": true
+  }
+}

--- a/mde-services/src/main/resources/config-services.json
+++ b/mde-services/src/main/resources/config-services.json
@@ -1,0 +1,17 @@
+{
+  "url": "https://inspire.ec.europa.eu/validator/",
+  "sort": "20103",
+  "testClassName": {
+    "de": "INSPIRE Metadata TG 2.0 - invocable spatial data services",
+    "en": "INSPIRE Metadata TG 2.0 - invocable spatial data services"
+  },
+  "helpTextDe": "Hier können Sie ggf. weitere optionale Konformitätsklassen hinzuwählen, bspw. für die Prüfung der Konformität zu bestimmten Applikationsschemata oder spezifischen Metadaten-Anforderungen.",
+  "helpTextEn": "If necessary, you can add further optional conformance classes here, e.g. for checking conformance to certain application schemas or specific metadata requirements.",
+  "conformanceClasses": {
+    "EID59692c11-df86-49ad-be7f-94a1e1ddd8da": true,
+    "EID8f869e23-c9e9-4e86-8dca-be30ff421229": true,
+    "EID8db54d8a-8578-4959-b891-5394d9f53a28": true,
+    "EID7514777a-6cb8-499c-acd5-912496dc84e9": false,
+    "EIDa593a7ad-42d9-46d0-985d-9dff3e684428": false
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <spring-boot.version>3.4.0</spring-boot.version>
     <log4j.version>2.24.1</log4j.version>
     <hibernate-search.version>7.2.2.Final</hibernate-search.version>
-    <testsuite.version>1.1.18</testsuite.version>
+    <testsuite.version>1.1.20</testsuite.version>
   </properties>
 
   <repositories>
@@ -363,6 +363,11 @@
       <dependency>
         <groupId>de.terrestris</groupId>
         <artifactId>bkg-testsuite-te</artifactId>
+        <version>${testsuite.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>de.terrestris</groupId>
+        <artifactId>bkg-testsuite-etf</artifactId>
         <version>${testsuite.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Adds the three metadata test classes from the INSPIRE validator (data sets, network services and spatial data services). Also fixes some issues with the generation of metadata to enable the generated metadata to be validated without issues, except for the SDS test class which expects the serviceType to be "other" as opposed to the network services tests which expect the serviceType to be "download" or "view".

@KaiVolland Please review.