### PR TITLE
Add HTTP requests for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ You can also modify your lucene directory to point somewhere else, it will be re
 
 Example call:
 
+```bash
 CODELISTS_DIR=../../mde-docker/codelists/ VARIABLE_FILE=../../mde-docker/mde-backend/variables.json $JAVA_HOME/bin/java --add-modules jdk.incubator.vector -Dhibernate.search.backend.directory.root=/tmp/lucene -jar target/mde-importer-0.0.1-SNAPSHOT-spring-boot.jar -d ~/geodata/berlin/export/
+```
 
 Please note that the importer expects the postgres database to live on localhost port 5432, so you might need to
 temporarily expose the postgres port to your machine, for example by adding a ports section to your compose file:

--- a/mde-backend-requests.http
+++ b/mde-backend-requests.http
@@ -1,0 +1,64 @@
+# Requests
+
+## Keycloak
+
+### Get access token
+# @name login
+POST https://{{auth_url}}/auth/realms/metadata-editor/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+
+client_id=mde&client_secret={{client_secret}}&grant_type=client_credentials
+
+## MDE Backend
+
+### Delete record
+@token = {{login.response.body.access_token}}
+DELETE https://{{backend_url}}/api/metadata/123
+Authorization: Bearer {{token}}
+
+## Geonetwork
+
+### Get all records
+POST https://{{gnos_url}}/geonetwork/srv/eng/csw
+Content-Type: application/xml
+Authorization: {{gnos_user}}:{{gnos_password}}
+
+<?xml version="1.0" encoding="UTF-8"?>
+<csw:GetRecords
+  xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+  service="CSW"
+  version="2.0.2"
+  resultType="results"
+  maxRecords="10"
+>
+  <csw:Query typeNames="csw:Record">
+    <csw:ElementSetName>full</csw:ElementSetName>
+  </csw:Query>
+</csw:GetRecords>
+
+### Get record by id
+POST https://{{gnos_url}}/geonetwork/srv/eng/csw
+Content-Type: application/xml
+Authorization: {{gnos_user}}:{{gnos_password}}
+
+<?xml version="1.0" encoding="UTF-8"?>
+<csw:GetRecords
+  xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  service="CSW"
+  version="2.0.2"
+  resultType="results"
+  maxRecords="100"
+>
+  <csw:Query typeNames="csw:Record">
+    <csw:ElementSetName>full</csw:ElementSetName>
+    <csw:Constraint version="1.1.0">
+      <ogc:Filter>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>dc:identifier</ogc:PropertyName>
+          <ogc:Literal>20619733-2ab7-4b23-ac2f-a9a0afdee618</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+      </ogc:Filter>
+    </csw:Constraint>
+  </csw:Query>
+</csw:GetRecords>


### PR DESCRIPTION
This adds some common HTTP request configs to be used within the [rest-client vscode](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension for local development. The configs are using environment variables that can be added as follows in the `.vscode/settings.json`:

```json
{
  "rest-client.environmentVariables": {
    "$shared": {},
    "dev": {
      "auth_url": "localhost",
      "gnos_url": "localhost",
      "backend_url": "localhost",
      "client_secret": "YOUR_SECRET",
      "gnos_user": "THE_ADMIN_USER",
      "gnos_password": "THE_ADMIN_PASSWORD"
    }
  }
}
```

Please review @KaiVolland.