### PR TITLE
Enable OpenAPI docs

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/config/SpringdocConfig.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/config/SpringdocConfig.java
@@ -1,0 +1,61 @@
+package de.terrestris.mde.mde_backend.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SpringdocConfig {
+
+  protected String title = "MDE REST API";
+  protected String description = "This is the REST API description of the MDE API";
+  protected String version = "1.0.0";
+  protected String contactName = "terrestris GmbH & Co. KG";
+  protected String contactUrl = "https://www.terrestris.de";
+  protected String contactMail = "info@terrestris.de";
+  protected String license = "Apache License, Version 2.0";
+  protected String licenseUrl = "https://www.apache.org/licenses/LICENSE-2.0.txt";
+
+  @Bean
+  public OpenAPI customOpenAPI() {
+    return new OpenAPI()
+      .info(
+        new Info()
+          .title(title)
+          .version(version)
+          .description(description)
+          .contact(
+            new Contact()
+              .name(contactName)
+              .url(contactUrl)
+              .email(contactMail)
+          )
+          .license(
+            new License()
+              .name(license)
+              .url(licenseUrl)
+          )
+      )
+      .addSecurityItem(
+        new SecurityRequirement()
+          .addList("Bearer Authentication")
+      )
+      .components(
+        new Components()
+          .addSecuritySchemes(
+            "Bearer Authentication",
+            new SecurityScheme()
+              .name("Bearer Authentication")
+              .type(SecurityScheme.Type.HTTP)
+              .scheme("bearer")
+              .bearerFormat("JWT")
+          )
+      );
+  }
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/config/WebSecurityConfig.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/config/WebSecurityConfig.java
@@ -63,11 +63,19 @@ public class WebSecurityConfig {
 
         // TODO: Reenable CSRF
         http.csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
-                        authorizationManagerRequestMatcherRegistry
-                                .requestMatchers(HttpMethod.GET, "/metadata/**")
-                                    .permitAll()
-                                .anyRequest().authenticated())
+            .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
+                 authorizationManagerRequestMatcherRegistry
+                     .requestMatchers(HttpMethod.GET, "/metadata/**")
+                         .permitAll()
+                     .requestMatchers(
+                         "/swagger-ui/**",
+                         "/v3/api-docs",
+                         "/v3/api-docs/swagger-config"
+                     )
+                         .permitAll()
+                     .anyRequest()
+                         .authenticated()
+                )
                 .httpBasic(Customizer.withDefaults())
                 .sessionManagement(httpSecuritySessionManagementConfigurer -> httpSecuritySessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 

--- a/mde-services/src/main/resources/application.properties
+++ b/mde-services/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+server.forward-headers-strategy=framework
 spring.application.name=mde-backend
 spring.datasource.url=jdbc:postgresql://mde-postgres/mde
 spring.datasource.username=postgres


### PR DESCRIPTION
This enables anonymous access to the OpenAPI docs and configures some custom springdoc settings, e.g. for accepting a bearer token for authentication.

Please note: Since the application is usually being accessed from the reverse proxy, the following line needs to be added to the `/api/` location:

```
proxy_set_header X-Forwarded-Prefix /api;
```

Otherwise springdoc (and possible others) aren't aware of the proxy path.

(PR for this diff is upcoming as well.)

Please review @KaiVolland @hwbllmnn.