### PR TITLE
Add `DELETE /metadata/{metadataId}` interface

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/MetadataDeletionResponse.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/MetadataDeletionResponse.java
@@ -1,0 +1,16 @@
+package de.terrestris.mde.mde_backend.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MetadataDeletionResponse {
+
+  private String deletedMetadataCollection;
+
+  private List<String> deletedCatalogRecords;
+
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
@@ -59,10 +59,7 @@ public class MetadataCollectionService extends BaseMetadataService<MetadataColle
     @PostAuthorize("hasRole('ROLE_ADMIN') or hasPermission(returnObject.orElse(null), 'READ')")
     @Transactional(readOnly = true)
     public Optional<MetadataCollection> findOneByMetadataId(String metadataId) {
-        MetadataCollection metadataCollection = repository.findByMetadataId(metadataId)
-            .orElseThrow(() -> new NoSuchElementException("MetadataCollection not found for metadataId: " + metadataId));
-
-        return  Optional.of(metadataCollection);
+        return repository.findByMetadataId(metadataId);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
This adds the `/metadata/{metadataId}` interface to actually delete a metadata collections by it's id. All referenced catalog records will be deleted from the catalog as well.

![image](https://github.com/user-attachments/assets/ad67e408-8db3-4007-81ed-e4fd8276d38c)

Open for discussion: The response includes the _removed_ contents only, this might be adjusted to also include the _erroneous_ records including the error messages. Thoughts?

Please review @hwbllmnn @KaiVolland 