### PR TITLE
Introduces `approved` property

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java
@@ -653,4 +653,47 @@ public class MetadataCollectionController extends BaseMetadataController<Metadat
     }
   }
 
+  @PostMapping("/{metadataId}/approved")
+  public ResponseEntity<Void> approveMetadata(@PathVariable("metadataId") String metadataId) {
+    try {
+      service.setApprovalState(metadataId, true);
+      return new ResponseEntity<>(OK);
+    } catch (Exception e) {
+      log.error("Error while approving metadata with id {}: \n {}", metadataId, e.getMessage());
+      log.trace("Full stack trace: ", e);
+
+      throw new ResponseStatusException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        messageSource.getMessage(
+          "BASE_CONTROLLER.INTERNAL_SERVER_ERROR",
+          null,
+          LocaleContextHolder.getLocale()
+        ),
+        e
+      );
+    }
+  }
+
+  @DeleteMapping("/{metadataId}/approved")
+  public ResponseEntity<Void> disapproveMetadata(@PathVariable("metadataId") String metadataId) {
+    try {
+      service.setApprovalState(metadataId, false);
+      return new ResponseEntity<>(OK);
+    } catch (Exception e) {
+      log.error("Error while disapproving metadata with id {}: \n {}", metadataId, e.getMessage());
+      log.trace("Full stack trace: ", e);
+
+      throw new ResponseStatusException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        messageSource.getMessage(
+          "BASE_CONTROLLER.INTERNAL_SERVER_ERROR",
+          null,
+          LocaleContextHolder.getLocale()
+        ),
+        e
+      );
+    }
+  }
+
+
 }

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/MetadataCollection.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/MetadataCollection.java
@@ -30,10 +30,9 @@ public class MetadataCollection extends BaseMetadata {
   @Formula("(iso_metadata->>'title')")
   private String title;
 
-  // TODO: THIS SHOULD NOT BE FORMULA! The valid property in the iso_metadata is
-  //  not the same as the validation state of the metadata collection
-  @Formula("(iso_metadata->>'valid')::boolean")
-  private Boolean valid;
+  @Column
+  @Setter
+  private Boolean approved;
 
   @Column
   @Setter

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/QueryConfig.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/QueryConfig.java
@@ -16,7 +16,7 @@ public class QueryConfig {
 
     private Boolean isTeamMember;
 
-    private Boolean isValid;
+    private Boolean isApproved;
 
     private List<Role> assignedRoles;
 

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
@@ -406,4 +406,14 @@ public class MetadataCollectionService extends BaseMetadataService<MetadataColle
       .toList();
   }
 
+  @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#entity, 'UPDATE')")
+  @Transactional(isolation = Isolation.SERIALIZABLE)
+  public void setApprovalState(String metadataId, Boolean approved) {
+    MetadataCollection metadataCollection = repository.findByMetadataId(metadataId)
+      .orElseThrow(() -> new NoSuchElementException("MetadataCollection not found for metadataId: " + metadataId));
+
+    metadataCollection.setApproved(approved);
+    repository.save(metadataCollection);
+  }
+
 }

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/specification/MetadataCollectionSpecification.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/specification/MetadataCollectionSpecification.java
@@ -25,8 +25,8 @@ public class MetadataCollectionSpecification {
       }
 
       // Valid-Filter
-      if (config.getIsValid() != null) {
-        predicates.add(cb.equal(root.get("valid"), config.getIsValid()));
+      if (config.getIsApproved() != null) {
+        predicates.add(cb.equal(root.get("approved"), config.getIsApproved()));
       }
 
       // Assigned-Filter

--- a/mde-services/src/main/resources/db/migration/V2.0.4__approved_column.sql
+++ b/mde-services/src/main/resources/db/migration/V2.0.4__approved_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE metadata_collection ADD COLUMN approved BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
This pull request introduces new functionality to manage the approval state of metadata collections and updates related components accordingly. The key changes include adding endpoints for approval and disapproval, modifying the data model to include an `approved` field, and updating related service and specification classes.

### New functionality for metadata approval:

* [`mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java`](diffhunk://#diff-6b1097a945ce542e2bf6cd0f762eebbd8115938b33d5aec0558e1e89981bd3baR656-R698): Added `approveMetadata` and `disapproveMetadata` endpoints to handle the approval state of metadata collections.

### Data model updates:

* [`mde-services/src/main/java/de/terrestris/mde/mde_backend/model/MetadataCollection.java`](diffhunk://#diff-5fdadaea90f5a67d0fd885f80f71619dfb4d7c62317803bbcc6515bde0daa0b0L33-R35): Replaced the `valid` field with a new `approved` field to represent the approval state.
* [`mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/QueryConfig.java`](diffhunk://#diff-736baff3a82ed8de72564938cdd5a9e7df25efbfc21fe6f9f2feb8aebeff2014L19-R19): Updated the `QueryConfig` class to use `isApproved` instead of `isValid`.

### Service and specification updates:

* [`mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java`](diffhunk://#diff-e8f6945a4c3cc35a3b6200802a640573a0b718c8916531abbb47d982eadda2bfR409-R418): Added a `setApprovalState` method to update the approval state of a metadata collection.
* [`mde-services/src/main/java/de/terrestris/mde/mde_backend/specification/MetadataCollectionSpecification.java`](diffhunk://#diff-ca239c11227956c4d2ffb7d5511d3001e0c0cd5c61c86712e2654c037a855690L28-R29): Updated the search specification to filter by the `approved` field instead of `valid`.

### Database migration:

* [`mde-services/src/main/resources/db/migration/V2.0.4__approved_column.sql`](diffhunk://#diff-9d452e472d71791d90b45114224c80cae6822be6b1e88ab48680e4fec85b15a0R1): Added a new `approved` column to the `metadata_collection` table with a default value of `FALSE`.