### PR TITLE
Update role assignment

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
@@ -301,15 +301,18 @@ public class MetadataCollectionService extends BaseMetadataService<MetadataColle
         .orElseThrow(() -> new NoSuchElementException("MetadataCollection not found for metadataId: " + metadataId));
 
       String assignedUserId = metadataCollection.getAssignedUserId();
-      List<RoleRepresentation> keycloakUserRoles = keycloakService.getRealmRoles(assignedUserId);
-      List<String> keycloakUserRoleNames = keycloakUserRoles.stream().map(RoleRepresentation::getName).toList();
 
-      if (!keycloakUserRoleNames.contains(role)) {
-        this.unassignUser(metadataId);
+      if (assignedUserId != null) {
+        List<RoleRepresentation> keycloakUserRoles = keycloakService.getRealmRoles(assignedUserId);
+        List<String> keycloakUserRoleNames = keycloakUserRoles.stream().map(RoleRepresentation::getName).toList();
+
+        if (!keycloakUserRoleNames.contains(role)) {
+          this.unassignUser(metadataId);
+        }
       }
 
       metadataCollection.setResponsibleRole(Role.valueOf(role));
-        repository.save(metadataCollection);
+      repository.save(metadataCollection);
     }
 
     @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#entity, 'UPDATE')")


### PR DESCRIPTION
This pull request includes a change to the `MetadataCollectionService` class to improve role assignment logic by adding a null check for the assigned user ID.

* [`mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java`](diffhunk://#diff-e8f6945a4c3cc35a3b6200802a640573a0b718c8916531abbb47d982eadda2bfR304-R312): Added a null check for `assignedUserId` before retrieving Keycloak user roles to prevent potential null pointer exceptions.