### PR TITLE
Rename roles

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/enumeration/Role.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/enumeration/Role.java
@@ -7,19 +7,19 @@ public enum Role {
     /**
      * Administrator role. (Administrator)
      */
-    Administrator("Administrator"),
+    MdeAdministrator("MdeAdministrator"),
     /**
      * DataOwner role. (Datenhaltende Stelle)
      */
-    DataOwner("DataOwner"),
+    MdeDataOwner("MdeDataOwner"),
     /**
      * Editor role. (Redakteur)
      */
-    Editor("Editor"),
+    MdeEditor("MdeEditor"),
     /**
      * QualityAssurance role. (QS)
      */
-    QualityAssurance("QualityAssurance");
+    MdeQualityAssurance("MdeQualityAssurance");
 
     private final String type;
 

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/security/MdePermissionEvaluator.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/security/MdePermissionEvaluator.java
@@ -15,7 +15,7 @@ public class MdePermissionEvaluator implements PermissionEvaluator {
 
     @Override
     public boolean hasPermission(Authentication authentication, Object targetDomainObject, Object permission) {
-        List<Role> allowedRoles = List.of(Role.Administrator, Role.Editor, Role.QualityAssurance, Role.DataOwner);
+        List<Role> allowedRoles = List.of(Role.MdeAdministrator, Role.MdeEditor, Role.MdeQualityAssurance, Role.MdeDataOwner);
         return allowedRoles.stream()
                 .anyMatch(role -> authentication.getAuthorities().stream()
                     .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals(role.toString()))

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
@@ -99,9 +99,9 @@ public class MetadataCollectionService extends BaseMetadataService<MetadataColle
       Role roleToSet = null;
       List<String> roleNames = authorities.stream().map(GrantedAuthority::getAuthority).toList();
       if (roleNames.contains("Editor")) {
-        roleToSet = Role.Editor;
+        roleToSet = Role.MdeEditor;
       } else if (roleNames.contains("DataOwner")) {
-        roleToSet = Role.DataOwner;
+        roleToSet = Role.MdeDataOwner;
       }
       if (roleToSet != null) {
         metadataCollection.setResponsibleRole(roleToSet);
@@ -156,9 +156,9 @@ public class MetadataCollectionService extends BaseMetadataService<MetadataColle
       Role roleToSet = null;
       List<String> roleNames = authorities.stream().map(GrantedAuthority::getAuthority).toList();
       if (roleNames.contains("Editor")) {
-        roleToSet = Role.Editor;
+        roleToSet = Role.MdeEditor;
       } else if (roleNames.contains("DataOwner")) {
-        roleToSet = Role.DataOwner;
+        roleToSet = Role.MdeDataOwner;
       }
       if (roleToSet != null) {
         metadataCollection.setResponsibleRole(roleToSet);


### PR DESCRIPTION
This renames the roles to include a `Mde` prefix each. NOTE! You'll need to rename them in keycloak/AD as well, so that they're called `MdeAdministrator`, `MdeEditor` and so forth.