### PR TITLE
Add server-sent event handling for validation

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/MdeBackendApplication.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/MdeBackendApplication.java
@@ -6,10 +6,12 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @SpringBootConfiguration
 @EnableAutoConfiguration
+@EnableScheduling
 @Configuration
 @PropertySource(value = "classpath:/application.properties", encoding = "UTF8")
 @PropertySource(ignoreResourceNotFound = true, value = "file:///config/application.properties", encoding = "UTF8")

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/config/AsyncExecutorConfig.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/config/AsyncExecutorConfig.java
@@ -1,0 +1,45 @@
+package de.terrestris.mde.mde_backend.config;
+
+import de.terrestris.mde.mde_backend.thread.TrackingExecutorService;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RejectedExecutionHandler;
+
+@Configuration
+@Log4j2
+public class AsyncExecutorConfig {
+
+  @Bean
+  public TrackingExecutorService trackingTaskExecutor() {
+    int corePoolSize = 5;
+    int maxPoolSize = 5;
+    int queueCapacity = 10;
+
+    RejectedExecutionHandler rejectionHandler = (r, executor) -> {
+      try {
+        log.warn("Queue full, blocking task submission…");
+        executor.getQueue().put(r);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RejectedExecutionException("Task submission interrupted", e);
+      }
+    };
+
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(corePoolSize);
+    executor.setMaxPoolSize(maxPoolSize);
+    executor.setQueueCapacity(queueCapacity);
+    executor.setThreadNamePrefix("MDE-Thread-Executor");
+    executor.setAllowCoreThreadTimeOut(true);
+    executor.setKeepAliveSeconds(60);
+    executor.setRejectedExecutionHandler(rejectionHandler);
+
+    executor.initialize();
+
+    return new TrackingExecutorService(executor.getThreadPoolExecutor());
+  }
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/config/BaseConfig.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/config/BaseConfig.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-
 @Configuration
 public class BaseConfig {
 

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/SseController.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/SseController.java
@@ -1,0 +1,75 @@
+package de.terrestris.mde.mde_backend.controller;
+
+import de.terrestris.mde.mde_backend.service.SseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Log4j2
+@RestController
+@RequestMapping("/events")
+public class SseController {
+
+  @Autowired
+  protected MessageSource messageSource;
+
+  @Autowired
+  private SseService service;
+
+  @GetMapping("/subscribe")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "Subscribe to server sent events",
+    description = "Calling this endpoint will create a new server sent event emitter and return it. " +
+      "The client can then listen to the events sent by the server, e.g. for updates of the validation process.",
+    security = { @SecurityRequirement(name = "Bearer Authentication") }
+  )
+  @ApiResponses(value = {
+    @ApiResponse(
+      responseCode = "200",
+      description = "Ok: Successfully subscribed to the events",
+      content = @Content
+    ),
+    @ApiResponse(
+      responseCode = "401",
+      description = "Unauthorized: You need to provide a bearer token",
+      content = @Content
+    ),
+    @ApiResponse(
+      responseCode = "500",
+      description = "Internal Server Error: Something internal went wrong while subscribing to the server sent events",
+      content = @Content
+    )
+  })
+  public SseEmitter subscribe() {
+    try {
+      return service.createEmitter();
+    } catch (Exception e) {
+      log.error("Error creating the SSE emitter: {}", e.getMessage());
+      log.trace("Full stack trace: ", e);
+
+      throw new ResponseStatusException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        messageSource.getMessage(
+          "BASE_CONTROLLER.INTERNAL_SERVER_ERROR",
+          null,
+          LocaleContextHolder.getLocale()
+        ),
+        e
+      );
+    }
+  }
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/enumeration/ValidationStatus.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/enumeration/ValidationStatus.java
@@ -1,0 +1,14 @@
+package de.terrestris.mde.mde_backend.enumeration;
+
+public enum ValidationStatus {
+  PENDING("PENDING"),
+  RUNNING("RUNNING"),
+  FINISHED("FINISHED"),
+  FAILED("FAILED");
+
+  private final String type;
+
+  ValidationStatus(String type) {
+    this.type = type;
+  }
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/event/sse/SseEvent.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/event/sse/SseEvent.java
@@ -1,0 +1,15 @@
+package de.terrestris.mde.mde_backend.event.sse;
+
+import de.terrestris.mde.mde_backend.model.dto.sse.SseMessage;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public abstract class SseEvent extends ApplicationEvent {
+  private final SseMessage message;
+
+  public SseEvent(Object source, SseMessage message) {
+    super(source);
+    this.message = message;
+  }
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/event/sse/validation/ValidationEvent.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/event/sse/validation/ValidationEvent.java
@@ -1,0 +1,16 @@
+package de.terrestris.mde.mde_backend.event.sse.validation;
+
+import de.terrestris.mde.mde_backend.event.sse.SseEvent;
+import de.terrestris.mde.mde_backend.model.dto.sse.SseMessage;
+import lombok.Getter;
+
+@Getter
+public class ValidationEvent extends SseEvent {
+  private final String keycloakId;
+
+  public ValidationEvent(Object source, SseMessage message, String keycloakId) {
+    super(source, message);
+
+    this.keycloakId = keycloakId;
+  }
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/event/sse/validation/ValidationEventListener.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/event/sse/validation/ValidationEventListener.java
@@ -1,0 +1,19 @@
+package de.terrestris.mde.mde_backend.event.sse.validation;
+
+import de.terrestris.mde.mde_backend.service.SseService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ValidationEventListener {
+
+  @Autowired
+  private SseService sseService;
+
+  @EventListener
+  public void onValidationEvent(ValidationEvent event) {
+    sseService.send("validation", event.getKeycloakId(), event.getMessage());
+  }
+
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/event/sse/validation/ValidationEventPublisher.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/event/sse/validation/ValidationEventPublisher.java
@@ -1,0 +1,31 @@
+package de.terrestris.mde.mde_backend.event.sse.validation;
+
+import de.terrestris.mde.mde_backend.model.dto.sse.ValidationMessage;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+@Component
+@Log4j2
+public class ValidationEventPublisher {
+  private final ApplicationEventPublisher publisher;
+
+  public ValidationEventPublisher(ApplicationEventPublisher publisher) {
+    this.publisher = publisher;
+  }
+
+  public void publishEvent(ValidationMessage message) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    if (!(authentication instanceof JwtAuthenticationToken)) {
+     throw new RuntimeException("Could not publish event, user probably not logged in");
+    }
+
+    String keycloakId = ((JwtAuthenticationToken) authentication).getToken().getClaimAsString("sub");
+
+    publisher.publishEvent(new ValidationEvent(this, message, keycloakId));
+  }
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/sse/HeartbeatMessage.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/sse/HeartbeatMessage.java
@@ -1,0 +1,14 @@
+package de.terrestris.mde.mde_backend.model.dto.sse;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class HeartbeatMessage extends SseMessage {
+  public HeartbeatMessage(String message) {
+    super(message);
+  }
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/sse/SseMessage.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/sse/SseMessage.java
@@ -1,0 +1,16 @@
+package de.terrestris.mde.mde_backend.model.dto.sse;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class SseMessage implements Serializable {
+  private String message;
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/sse/ValidationMessage.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/sse/ValidationMessage.java
@@ -1,0 +1,23 @@
+package de.terrestris.mde.mde_backend.model.dto.sse;
+
+import de.terrestris.mde.mde_backend.enumeration.ValidationStatus;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class ValidationMessage extends SseMessage {
+
+  private String metadataId;
+
+  private ValidationStatus status;
+
+  public ValidationMessage(String metadataId, String message, ValidationStatus status) {
+    super(message);
+
+    this.status = status;
+    this.metadataId = metadataId;
+  }
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/SseService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/SseService.java
@@ -1,0 +1,123 @@
+package de.terrestris.mde.mde_backend.service;
+
+import de.terrestris.mde.mde_backend.model.dto.sse.HeartbeatMessage;
+import de.terrestris.mde.mde_backend.model.dto.sse.SseMessage;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@Log4j2
+public class SseService {
+
+  private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+  /**
+   * Creates a new SseEmitter and associates it with the Keycloak ID of the authenticated user.
+   *
+   * @return The created SseEmitter.
+   * @throws Exception If the authentication is not a JwtAuthenticationToken.
+   */
+  @PreAuthorize("isAuthenticated()")
+  public SseEmitter createEmitter() throws Exception {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    if (!(authentication instanceof JwtAuthenticationToken)) {
+      throw new Exception("Authentication is not a JwtAuthenticationToken");
+    }
+
+    String keycloakId = ((JwtAuthenticationToken) authentication).getToken().getClaimAsString("sub");
+
+    SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+
+    if (emitters.get(keycloakId) != null) {
+      log.debug("Emitter already exists for keycloak ID: {}", keycloakId);
+
+      return emitters.get(keycloakId);
+    }
+
+    emitters.put(keycloakId, emitter);
+
+    emitter.onCompletion(() -> {
+      log.info("Emitter completed");
+      emitters.remove(keycloakId);
+    });
+    emitter.onTimeout(() -> {
+      log.info("Emitter timed out");
+      emitters.remove(keycloakId);
+    });
+    emitter.onError(e -> {
+      log.info("Error in emitter: {}", e.getMessage());
+      emitters.remove(keycloakId);
+    });
+
+    return emitter;
+  }
+
+  /**
+   * Sends a message to the emitter associated with the given keycloak ID.
+   *
+   * @param name       The name of the event.
+   * @param keycloakId The keycloak ID of the user.
+   * @param message    The message to send.
+   */
+  public void send(String name, String keycloakId, SseMessage message) {
+    SseEmitter emitter = emitters.get(keycloakId);
+
+    if (emitter == null) {
+      log.warn("No emitter found for keycloak ID: {}", keycloakId);
+      return;
+    }
+
+    try {
+      emitter.send(SseEmitter.event()
+        // TODO Check if id is needed, can most probably be omitted
+        .name(name)
+        .data(message)
+      );
+    } catch (IOException e) {
+      emitter.completeWithError(e);
+      emitters.remove(keycloakId);
+    }
+  }
+
+  /**
+   * Broadcasts a message to all emitters.
+   *
+   * @param name    The name of the event.
+   * @param message The message to send.
+   */
+  public void broadcast(String name, SseMessage message) {
+    emitters.forEach((keycloakId, emitter) -> {
+      try {
+        emitter.send(SseEmitter.event()
+          .name(name)
+          .data(message)
+        );
+      } catch (IOException e) {
+        emitter.completeWithError(e);
+        emitters.remove(keycloakId);
+      }
+    });
+  }
+
+  /**
+   * Sends a heartbeat message to all emitters every 15 seconds to prevent
+   * any timeout (even if set otherwise on the used emitter).
+   */
+  // TODO Make rate configurable via application.properties
+  @Scheduled(fixedRate = 15000)
+  public void sendHeartbeat() {
+    broadcast("heartbeat", new HeartbeatMessage("Hello There"));
+  }
+
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/thread/TrackedTask.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/thread/TrackedTask.java
@@ -1,0 +1,21 @@
+package de.terrestris.mde.mde_backend.thread;
+
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@ToString
+public class TrackedTask implements Runnable {
+  private final String taskId;
+  private final Runnable delegate;
+
+  public TrackedTask(String taskId, Runnable delegate) {
+    this.taskId = taskId;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void run() {
+    delegate.run();
+  }
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/thread/TrackingExecutorService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/thread/TrackingExecutorService.java
@@ -1,0 +1,127 @@
+package de.terrestris.mde.mde_backend.thread;
+
+import lombok.extern.log4j.Log4j2;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * An {@link ExecutorService} that tracks the number of running tasks and provides
+ * methods to retrieve the count and the set of currently running tasks.
+ *
+ * @see ExecutorService
+ */
+@Log4j2
+public class TrackingExecutorService implements ExecutorService {
+
+  private final ExecutorService delegate;
+  private final AtomicInteger runningTasks = new AtomicInteger(0);
+  private final Set<Runnable> currentTasks = ConcurrentHashMap.newKeySet();
+
+  public TrackingExecutorService(ExecutorService delegate) {
+    this.delegate = delegate;
+  }
+
+  public int getRunningTaskCount() {
+    return runningTasks.get();
+  }
+
+  public Set<Runnable> getRunningTasks() {
+    return Collections.unmodifiableSet(currentTasks);
+  }
+
+  private Runnable wrap(Runnable task) {
+    return () -> {
+      currentTasks.add(task);
+      int current = runningTasks.incrementAndGet();
+      log.debug("Task started. Running tasks: {}", current);
+      try {
+        task.run();
+      } finally {
+        int remaining = runningTasks.decrementAndGet();
+        currentTasks.remove(task);
+        log.debug("Task finished. Remaining tasks: {}", remaining);
+      }
+    };
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    delegate.execute(wrap(command));
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    return delegate.submit(wrap(task));
+  }
+
+  @Override public <T> Future<T> submit(Callable<T> task) {
+    return delegate.submit(() -> {
+      Runnable wrapped = wrap(() -> {
+        try {
+          task.call();
+        } catch (Exception e) {
+          throw new CompletionException(e);
+        }
+      });
+      wrapped.run();
+      return null;
+    });
+  }
+
+  @Override
+  public <T> Future<T> submit(Runnable task, T result) {
+    return delegate.submit(wrap(task), result);
+  }
+
+  @Override
+  public void shutdown() {
+    delegate.shutdown();
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    return delegate.shutdownNow();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return delegate.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return delegate.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return delegate.awaitTermination(timeout, unit);
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+    return delegate.invokeAll(tasks);
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+    throws InterruptedException {
+    return delegate.invokeAll(tasks, timeout, unit);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+    return delegate.invokeAny(tasks);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+    throws InterruptedException, ExecutionException, TimeoutException {
+    return delegate.invokeAny(tasks, timeout, unit);
+  }
+}


### PR DESCRIPTION
This includes the first draft for including global broadcasted and user specific [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events). Currently it's used for emitting any events for the validation process, but it may be adjusted to include other events.

The implementation for the validation process makes some assumptions (open for discussion of course):

- A metadata record can only be validated once in parallel
- The event emitter sends a start and end event only, no events in between, e.g. for the current progress
- There are no detailed permissions set yet, any authenticated user can connect to the events and start the validation

Please review @hwbllmnn @KaiVolland 