### PR TITLE
Featuretypes

### DIFF
--- a/mde-importer/src/main/java/de/terrestris/mde/mde_importer/importer/ImportService.java
+++ b/mde-importer/src/main/java/de/terrestris/mde/mde_importer/importer/ImportService.java
@@ -760,8 +760,8 @@ public class ImportService {
 
   private static List<Layer> extractMetadataFields(XMLStreamReader reader, Service service, JsonTechnicalMetadata technical) throws XMLStreamException, ParseException, URISyntaxException {
     var layers = new ArrayList<Layer>();
-    if (service.getColumns() == null) {
-      service.setColumns(new ArrayList<>());
+    if (service.getFeatureTypes() == null) {
+      service.setFeatureTypes(new ArrayList<>());
     }
     if (technical.getCategories() == null) {
       technical.setCategories(new ArrayList<>());
@@ -852,7 +852,14 @@ public class ImportService {
         break;
       case "SelectColumn":
         var columnInfo = new ColumnInfo();
-        service.getColumns().add(columnInfo);
+        var featureTypes = service.getFeatureTypes();
+
+        // TODO: handle multiple featuretypes in xml
+        var featureType = new FeatureType();
+        featureType.setColumns(new ArrayList<>());
+        featureType.getColumns().add(columnInfo);
+        featureTypes.add(featureType);
+
         while (reader.hasNext() && !(reader.isEndElement() && reader.getLocalName().equals("SelectColumn"))) {
           reader.next();
           if (!reader.isStartElement()) {
@@ -863,10 +870,7 @@ public class ImportService {
               columnInfo.setName(reader.getElementText());
               break;
             case "ColumnAlias":
-              columnInfo.setTitle(reader.getElementText());
-              break;
-            case "ColumnDescription":
-              columnInfo.setDescription(reader.getElementText());
+              columnInfo.setAlias(reader.getElementText());
               break;
             case "ColumnType":
               String tp = reader.getElementText();

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/ColumnInfo.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/ColumnInfo.java
@@ -37,30 +37,10 @@ public class ColumnInfo {
 
   private String name;
 
-  private String title;
-
-  private String description;
+  private String alias;
 
   private ColumnType type;
 
-  private boolean listView;
-
-  private boolean listViewEnabled;
-
-  private boolean elementView;
-
-  private boolean elementViewEnabled;
-
-  private boolean statisticsView;
-
   private FilterType filterType;
-
-  private String minFilterValue;
-
-  private String maxFilterValue;
-
-  private String minOrderValue;
-
-  private String maxOrderValue;
 
 }

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/FeatureType.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/FeatureType.java
@@ -1,0 +1,24 @@
+package de.terrestris.mde.mde_backend.model.json;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@JsonDeserialize(as = FeatureType.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@NoArgsConstructor(force = true)
+@AllArgsConstructor
+public class FeatureType {
+
+  private List<ColumnInfo> columns;
+
+  private String name;
+
+  private String title;
+
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/Service.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/Service.java
@@ -65,7 +65,7 @@ public class Service implements FileIdentifier {
 
   private String preview;
 
-  private List<ColumnInfo> columns;
+  private List<FeatureType> featureTypes;
 
   private List<DownloadInfo> downloads;
 


### PR DESCRIPTION
This pull request includes several changes to the `mde-importer` and `mde-services` modules, primarily focusing on the handling of metadata fields and the structure of the `Service` and `FeatureType` classes. The most important changes include modifying the `Service` class to use `FeatureType` instead of `ColumnInfo`, updating the `ImportService` to handle these changes, and adding a new `FeatureType` class.

Changes to metadata handling:

* [`mde-importer/src/main/java/de/terrestris/mde/mde_importer/importer/ImportService.java`](diffhunk://#diff-39f6161dce81e6ba42ef2346da921144b85e8a9cd6a76a647737f49c02589f17L763-R764): Replaced `service.getColumns()` with `service.getFeatureTypes()` and updated the logic to handle `FeatureType` objects. [[1]](diffhunk://#diff-39f6161dce81e6ba42ef2346da921144b85e8a9cd6a76a647737f49c02589f17L763-R764) [[2]](diffhunk://#diff-39f6161dce81e6ba42ef2346da921144b85e8a9cd6a76a647737f49c02589f17L855-R862)

Changes to data structure:

* [`mde-services/src/main/java/de/terrestris/mde_mde_backend/model/json/Service.java`](diffhunk://#diff-f169b2b8a9a2b54c2fb11199972bb7ea22bdebdd75b1546df74d8bfc585cac2aL68-R68): Changed the `columns` field to `featureTypes` to accommodate the new `FeatureType` structure.
* [`mde-services/src/main/java/de/terrestris/mde_mde_backend/model/json/FeatureType.java`](diffhunk://#diff-4db0d6586196d6a31917542f7473988a7f85d0853a8179f571021e77939a7573R1-R24): Added a new `FeatureType` class to represent feature types with a list of columns, name, and title.

Changes to column information:

* [`mde-importer/src/main/java/de/terrestris/mde_mde_importer/importer/ImportService.java`](diffhunk://#diff-39f6161dce81e6ba42ef2346da921144b85e8a9cd6a76a647737f49c02589f17L866-R873): Updated the `extractMetadataFields` method to set `columnInfo` attributes appropriately, including changing `title` to `alias`.
* [`mde-services/src/main/java/de/terrestris/mde_mde_backend/model/json/ColumnInfo.java`](diffhunk://#diff-872459652ed8393635cc792bd13fb0201a3aea216b229ac02743494428ec8908L40-L65): Removed `title` and `description` fields and added an `alias` field to the `ColumnInfo` class.

:warning: This removes several unused properties from the `ColumnInfo`. Also it changes the `Service` model so the Database has to be reset. Truncate the metadata_collection table and rerun the importer.