### PR TITLE
Require authentication for all requests (except OpenAPI)

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/config/WebSecurityConfig.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/config/WebSecurityConfig.java
@@ -65,8 +65,6 @@ public class WebSecurityConfig {
         http.csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
                  authorizationManagerRequestMatcherRegistry
-                     .requestMatchers(HttpMethod.GET, "/metadata/**")
-                         .permitAll()
                      .requestMatchers(
                          "/swagger-ui/**",
                          "/v3/api-docs",


### PR DESCRIPTION
Now requires authentication for `/metadata/**` GET requests.

Please note @hwbllmnn @KaiVolland.