### PR TITLE
Layers (mapping and updating)

### DIFF
--- a/mde-importer/src/main/java/de/terrestris/mde/mde_importer/importer/ImportService.java
+++ b/mde-importer/src/main/java/de/terrestris/mde/mde_importer/importer/ImportService.java
@@ -624,12 +624,15 @@ public class ImportService {
       }
 
       extractIsoFields(reader, service);
-      clientMetadata.getLayers().put(service.getFileIdentifier(), layers);
       parseCapabilities(service, clientMetadata);
+
       if (replaceValues(service.getUrl()).contains("fbadmin.senstadtdmz.verwalt-berlin.de")) {
         isoMetadata.getServices().removeLast();
         log.info("Removing service as it's not migrated yet.");
+      } else {
+        clientMetadata.getLayers().put(service.getServiceIdentification(), layers);
       }
+
     } catch (XMLStreamException | IOException | ParseException | URISyntaxException e) {
       log.warn("Problem while adding service from {}: {}", file, e.getMessage());
       log.trace("Stack trace", e);
@@ -712,14 +715,7 @@ public class ImportService {
           layer.setStyleName(reader.getElementText());
           break;
         case "LegendURL":
-          var legend = new LegendImage();
-          legend.setWidth(Integer.parseInt(reader.getAttributeValue(null, "width")));
-          legend.setHeight(Integer.parseInt(reader.getAttributeValue(null, "height")));
-          skipToElement(reader, "Format");
-          legend.setFormat(reader.getElementText());
-          skipToElement(reader, "OnlineResource");
-          legend.setUrl(reader.getAttributeValue(XLINK, "href"));
-          layer.setLegendImage(legend);
+          layer.setLegendImage(reader.getAttributeValue(XLINK, "href"));
           break;
       }
     }
@@ -904,7 +900,6 @@ public class ImportService {
       case "Kartenebene":
         var layer = new Layer();
         layers.add(layer);
-        layer.setRelatedTopic(reader.getAttributeValue(null, "mt_klasse"));
         layer.setName(reader.getAttributeValue(null, "name"));
         while (reader.hasNext() && !(reader.isEndElement() && reader.getLocalName().equals("Kartenebene"))) {
           reader.next();
@@ -923,13 +918,7 @@ public class ImportService {
               layer.setStyleTitle(reader.getAttributeValue(null, "title"));
               break;
             case "LegendImage":
-              var image = new LegendImage(
-                reader.getAttributeValue(null, "format"),
-                reader.getAttributeValue(null, "url"),
-                Integer.parseInt(reader.getAttributeValue(null, "width")),
-                Integer.parseInt(reader.getAttributeValue(null, "height"))
-              );
-              layer.setLegendImage(image);
+              layer.setLegendImage(reader.getAttributeValue(null, "url"));
               break;
           }
         }

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java
@@ -5,6 +5,7 @@ import de.terrestris.mde.mde_backend.model.BaseMetadata;
 import de.terrestris.mde.mde_backend.model.MetadataCollection;
 import de.terrestris.mde.mde_backend.model.dto.*;
 import de.terrestris.mde.mde_backend.model.json.Comment;
+import de.terrestris.mde.mde_backend.model.json.Layer;
 import de.terrestris.mde.mde_backend.model.json.Service;
 import de.terrestris.mde.mde_backend.service.*;
 import de.terrestris.mde.mde_backend.thread.TrackedTask;
@@ -202,6 +203,30 @@ public class MetadataCollectionController extends BaseMetadataController<Metadat
       // TODO: Add more specific exception handling
     } catch (Exception e) {
       log.error("Error while updating metadata with id {}: \n {}", metadataId, e.getMessage());
+      log.trace("Full stack trace: ", e);
+
+      throw new ResponseStatusException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        messageSource.getMessage(
+          "BASE_CONTROLLER.INTERNAL_SERVER_ERROR",
+          null,
+          LocaleContextHolder.getLocale()
+        ),
+        e
+      );
+    }
+  }
+
+  @PatchMapping("/{metadataId}/updateLayers/{serviceIdentification}")
+  public String updateLayers(
+    @PathVariable("metadataId") String metadataId,
+    @PathVariable("serviceIdentification") String serviceIdentification,
+    @RequestBody List<Layer> layers
+  ) {
+    try {
+      return service.updateLayers(metadataId, serviceIdentification, layers);
+    } catch (Exception e) {
+      log.error("Error while updating layers of metadata with id {} and serviceIdentification {}: \n {}", metadataId, serviceIdentification, e.getMessage());
       log.trace("Full stack trace: ", e);
 
       throw new ResponseStatusException(

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/JsonClientMetadata.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/JsonClientMetadata.java
@@ -31,6 +31,7 @@ public class JsonClientMetadata {
 
   private Extent initialExtent;
 
+  // Map of service.serviceIdentification and List of layers
   private Map<String, List<Layer>> layers;
 
 }

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/Layer.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/Layer.java
@@ -13,8 +13,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class Layer {
 
-  private String relatedTopic;
-
   private String name;
 
   private String title;
@@ -25,12 +23,10 @@ public class Layer {
 
   private String shortDescription;
 
-  private LegendImage legendImage;
-
-  private double minScale;
-
-  private double maxScale;
+  private String legendImage;
 
   private String datasource;
+
+  private String secondaryDatasource;
 
 }

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
@@ -10,10 +10,7 @@ import de.terrestris.mde.mde_backend.jpa.MetadataCollectionRepository;
 import de.terrestris.mde.mde_backend.model.MetadataCollection;
 import de.terrestris.mde.mde_backend.model.dto.QueryConfig;
 import de.terrestris.mde.mde_backend.model.dto.UserData;
-import de.terrestris.mde.mde_backend.model.json.Comment;
-import de.terrestris.mde.mde_backend.model.json.JsonClientMetadata;
-import de.terrestris.mde.mde_backend.model.json.JsonIsoMetadata;
-import de.terrestris.mde.mde_backend.model.json.JsonTechnicalMetadata;
+import de.terrestris.mde.mde_backend.model.json.*;
 import de.terrestris.mde.mde_backend.specification.MetadataCollectionSpecification;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -417,6 +414,27 @@ public class MetadataCollectionService extends BaseMetadataService<MetadataColle
 
     metadataCollection.setApproved(approved);
     repository.save(metadataCollection);
+  }
+
+  @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#entity, 'UPDATE')")
+  @Transactional(isolation = Isolation.SERIALIZABLE)
+  public String updateLayers(String metadataId, String serviceIdentification, List<Layer> layers) {
+    MetadataCollection metadataCollection = repository.findByMetadataId(metadataId)
+      .orElseThrow(() -> new NoSuchElementException("MetadataCollection not found for metadataId: " + metadataId));
+
+    JsonClientMetadata clientMetadata = metadataCollection.getClientMetadata();
+    Map<String, List<Layer>> layerMap = clientMetadata.getLayers();
+
+    if (layerMap == null) {
+      layerMap = new HashMap<>();
+    }
+
+    layerMap.put(serviceIdentification, layers);
+    clientMetadata.setLayers(layerMap);
+
+    repository.save(metadataCollection);
+
+    return serviceIdentification;
   }
 
 }


### PR DESCRIPTION
This pull request includes significant changes to the `ImportService` and `MetadataCollectionController` classes to improve the handling of layers and services. The most important changes include modifying how legend images are set and adding a new endpoint for updating layers.

Changes to handling legend images and layers:

* [`mde-importer/src/main/java/de/terrestris/mde/mde_importer/importer/ImportService.java`](diffhunk://#diff-39f6161dce81e6ba42ef2346da921144b85e8a9cd6a76a647737f49c02589f17L715-R718): Simplified the setting of legend images by directly assigning the URL instead of creating a `LegendImage` object. [[1]](diffhunk://#diff-39f6161dce81e6ba42ef2346da921144b85e8a9cd6a76a647737f49c02589f17L715-R718) [[2]](diffhunk://#diff-39f6161dce81e6ba42ef2346da921144b85e8a9cd6a76a647737f49c02589f17L926-R921)
* [`mde-importer/src/main/java/de/terrestris/mde/mde_importer/importer/ImportService.java`](diffhunk://#diff-39f6161dce81e6ba42ef2346da921144b85e8a9cd6a76a647737f49c02589f17L907): Removed the `relatedTopic` attribute from layers during metadata extraction.

New endpoint for updating layers:

* [`mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java`](diffhunk://#diff-6b1097a945ce542e2bf6cd0f762eebbd8115938b33d5aec0558e1e89981bd3baR220-R243): Added a new `updateLayers` endpoint to allow updating layers of a metadata collection based on the service identification.

Changes to `Layer` class:

* [`mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/Layer.java`](diffhunk://#diff-5f8086755665d2b2144ef71599e0ef2a8adc4c01c58c5cac5efe835c622ec881L16-L17): Removed `relatedTopic`, `minScale`, and `maxScale` attributes, and simplified the `legendImage` attribute to store only the URL. [[1]](diffhunk://#diff-5f8086755665d2b2144ef71599e0ef2a8adc4c01c58c5cac5efe835c622ec881L16-L17) [[2]](diffhunk://#diff-5f8086755665d2b2144ef71599e0ef2a8adc4c01c58c5cac5efe835c622ec881L28-R31)

Other changes:

* [`mde-services/src/main/java/de/terrestris/mde_backend/service/MetadataCollectionService.java`](diffhunk://#diff-e8f6945a4c3cc35a3b6200802a640573a0b718c8916531abbb47d982eadda2bfR419-R439): Implemented the `updateLayers` method to support the new endpoint in `MetadataCollectionController`.


:warning: BREAKING CHANGE: removes properties from Layer and updates mapping of layers in JsonClientMetadata