### PR TITLE
Replace delimiter

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/ValidatorService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/ValidatorService.java
@@ -236,7 +236,7 @@ public class ValidatorService {
         List<String> result = this.validateMetadata(metadataId);
 
         eventPublisher.publishEvent(new ValidationMessage(metadataId,
-          String.join("\n", result), ValidationStatus.FINISHED));
+          String.join("|", result), ValidationStatus.FINISHED));
       } catch (IOException | XMLStreamException | RuntimeException e) {
         log.error("Error while validating metadata with id {}: \n {}", metadataId, e.getMessage());
         log.trace("Full stack trace: ", e);


### PR DESCRIPTION
This replaces the list delimiter (in the joined validation result string) to a pipe character to make the list more legible in the client.

Please review @hwbllmnn @KaiVolland