### PR TITLE
Transforms datatype of highValueDataCategory

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/JsonIsoMetadata.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/JsonIsoMetadata.java
@@ -88,7 +88,7 @@ public class JsonIsoMetadata implements FileIdentifier {
 
   private Map<String, Thesaurus> thesauri = new HashMap<>();
 
-  private String highValueDataCategory;
+  private List<String> highValueDataCategory;
 
   @JsonFormat(shape = STRING)
   private Instant dateTime;


### PR DESCRIPTION
Changed the `highValueDataCategory` field from a `String` to a `List<String>` to support multiple categories instead of a single value.

:warning: This is breaking change and requires a reimport of the DB, or and adequate transformation via SQL