### PR TITLE
Fix generation of INSPIRE theme keywords

### DIFF
--- a/mde-importer/src/main/java/de/terrestris/mde/mde_importer/importer/ImportService.java
+++ b/mde-importer/src/main/java/de/terrestris/mde/mde_importer/importer/ImportService.java
@@ -6,12 +6,12 @@ import de.terrestris.mde.mde_backend.model.MetadataCollection;
 import de.terrestris.mde.mde_backend.model.json.*;
 import de.terrestris.mde.mde_backend.model.json.ColumnInfo.ColumnType;
 import de.terrestris.mde.mde_backend.model.json.ColumnInfo.FilterType;
-import de.terrestris.mde.mde_backend.model.json.JsonIsoMetadata.InspireTheme;
 import de.terrestris.mde.mde_backend.model.json.Service.ServiceType;
 import de.terrestris.mde.mde_backend.model.json.codelists.CI_DateTypeCode;
 import de.terrestris.mde.mde_backend.model.json.codelists.CI_OnLineFunctionCode;
 import de.terrestris.mde.mde_backend.model.json.codelists.CI_RoleCode;
 import de.terrestris.mde.mde_backend.model.json.codelists.MD_MaintenanceFrequencyCode;
+import de.terrestris.mde.mde_backend.service.GeneratorUtils;
 import de.terrestris.mde.mde_backend.service.KeycloakService;
 import lombok.extern.log4j.Log4j2;
 import org.apache.http.client.utils.URIBuilder;
@@ -54,8 +54,6 @@ public class ImportService {
 
   private static final SimpleDateFormat FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 
-  public static final Map<String, JsonIsoMetadata.InspireTheme> INSPIRE_THEME_MAP;
-
   private static final Set<String> AUTO_KEYWORDS = Set.of(
     "inspireidentifiziert",
     "open data",
@@ -70,41 +68,6 @@ public class ImportService {
 
   static {
     FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
-    INSPIRE_THEME_MAP = new HashMap<>();
-    INSPIRE_THEME_MAP.put("Atmosphärische Bedingungen", InspireTheme.AC);
-    INSPIRE_THEME_MAP.put("Adressen", InspireTheme.AD);
-    INSPIRE_THEME_MAP.put("Landwirtschaftliche Anlagen und Aquakulturanlagen", InspireTheme.AF);
-    INSPIRE_THEME_MAP.put("Bewirtschaftungsgebiete/Schutzgebiete/geregelte Gebiete und Berichterstattungseinheiten", InspireTheme.AM);
-    INSPIRE_THEME_MAP.put("Verwaltungseinheiten", InspireTheme.AU);
-    INSPIRE_THEME_MAP.put("Biogeografische Regionen", InspireTheme.BR);
-    INSPIRE_THEME_MAP.put("Gebäude", InspireTheme.BU);
-    INSPIRE_THEME_MAP.put("Flurstücke/Grundstücke (Katasterparzellen)", InspireTheme.CP);
-    INSPIRE_THEME_MAP.put("Umweltüberwachung", InspireTheme.EF);
-    INSPIRE_THEME_MAP.put("Höhe", InspireTheme.EL);
-    INSPIRE_THEME_MAP.put("Energiequellen", InspireTheme.ER);
-    INSPIRE_THEME_MAP.put("Geologie", InspireTheme.GE);
-    INSPIRE_THEME_MAP.put("Geografische Gittersysteme", InspireTheme.GG);
-    INSPIRE_THEME_MAP.put("Geografische Bezeichnungen", InspireTheme.GN);
-    INSPIRE_THEME_MAP.put("Lebensräume und Biotope", InspireTheme.HB);
-    INSPIRE_THEME_MAP.put("Gesundheit und Sicherheit", InspireTheme.HH);
-    INSPIRE_THEME_MAP.put("Gewässernetz", InspireTheme.HY);
-    INSPIRE_THEME_MAP.put("Bodenbedeckung", InspireTheme.LC);
-    INSPIRE_THEME_MAP.put("Bodennutzung", InspireTheme.LU);
-    INSPIRE_THEME_MAP.put("Meteorologisch-geografische Kennwerte", InspireTheme.MF);
-    INSPIRE_THEME_MAP.put("Mineralische Bodenschätze", InspireTheme.MR);
-    INSPIRE_THEME_MAP.put("Gebiete mit naturbedingten Risiken", InspireTheme.NZ);
-    INSPIRE_THEME_MAP.put("Ozeanografisch-geografische Kennwerte", InspireTheme.OF);
-    INSPIRE_THEME_MAP.put("Orthofotografie", InspireTheme.OI);
-    INSPIRE_THEME_MAP.put("Verteilung der Bevölkerung — Demografie", InspireTheme.PD);
-    INSPIRE_THEME_MAP.put("Produktions- und Industrieanlagen", InspireTheme.PF);
-    INSPIRE_THEME_MAP.put("Schutzgebiete", InspireTheme.PS);
-    INSPIRE_THEME_MAP.put("Koordinatenreferenzsysteme", InspireTheme.RS);
-    INSPIRE_THEME_MAP.put("Verteilung der Arten", InspireTheme.SD);
-    INSPIRE_THEME_MAP.put("Boden", InspireTheme.SO);
-    INSPIRE_THEME_MAP.put("Meeresregionen", InspireTheme.SR);
-    INSPIRE_THEME_MAP.put("Statistische Einheiten", InspireTheme.SU);
-    INSPIRE_THEME_MAP.put("Verkehrsnetze", InspireTheme.TN);
-    INSPIRE_THEME_MAP.put("Versorgungswirtschaft und staatliche Dienste", InspireTheme.US);
   }
 
   @Autowired
@@ -581,13 +544,14 @@ public class ImportService {
       if (keywords.isEmpty()) {
         return;
       }
-      json.getKeywords().put(thesaurus.getTitle() == null ? "default" : thesaurus.getTitle(), keywords);
-      json.getThesauri().put(thesaurus.getTitle() == null ? "default" : thesaurus.getTitle(), thesaurus);
       if (thesaurus.getTitle() != null && thesaurus.getTitle().equals("GEMET - INSPIRE themes, version 1.0")) {
         if (json.getInspireTheme() == null) {
           json.setInspireTheme(new ArrayList<>());
         }
-        json.getInspireTheme().add(INSPIRE_THEME_MAP.get(keywords.getFirst().getKeyword()));
+        json.getInspireTheme().add(GeneratorUtils.INSPIRE_THEME_MAP.get(keywords.getFirst().getKeyword()));
+      } else {
+        json.getKeywords().put(thesaurus.getTitle() == null ? "default" : thesaurus.getTitle(), keywords);
+        json.getThesauri().put(thesaurus.getTitle() == null ? "default" : thesaurus.getTitle(), thesaurus);
       }
     }
   }

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/DatasetIsoGenerator.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/DatasetIsoGenerator.java
@@ -206,6 +206,7 @@ public class DatasetIsoGenerator {
     writeMaintenanceInfo(writer, metadata.getMaintenanceFrequency());
     writePreview(writer, metadata.getPreview());
     writeKeywords(writer, metadata);
+    writeInspireThemeKeywords(writer, metadata);
     writeResourceConstraints(writer, TERMS_OF_USE_BY_ID.get(metadata.getTermsOfUseId().intValue()));
     writeSpatialRepresentationType(writer);
     writeSpatialResolution(writer, metadata);
@@ -314,6 +315,37 @@ public class DatasetIsoGenerator {
       }
       writer.writeEndElement(); // MD_Keywords
       writer.writeEndElement(); // descriptiveKeywords
+    }
+  }
+
+  protected static void writeInspireThemeKeywords(XMLStreamWriter writer, JsonIsoMetadata metadata) throws XMLStreamException {
+    if (metadata.getInspireTheme() != null) {
+      for (var theme : metadata.getInspireTheme()) {
+        writer.writeStartElement(GMD, "descriptiveKeywords");
+        writer.writeStartElement(GMD, "MD_Keywords");
+        writer.writeStartElement(GMD, "keyword");
+        writeSimpleElement(writer, GCO, "CharacterString", INSPIRE_THEME_KEYWORD_MAP.get(theme));
+        writer.writeEndElement(); // keyword
+        writer.writeStartElement(GMD, "thesaurusName");
+        writer.writeStartElement(GMD, "CI_Citation");
+        writer.writeStartElement(GMD, "title");
+        writeSimpleElement(writer, GCO, "CharacterString", "GEMET - INSPIRE themes, version 1.0");
+        writer.writeEndElement(); // title
+        writer.writeStartElement(GMD, "date");
+        writer.writeStartElement(GMD, "CI_Date");
+        writer.writeStartElement(GMD, "date");
+        writeSimpleElement(writer, GCO, "Date", "2008-06-01");
+        writer.writeEndElement(); // date
+        writer.writeStartElement(GMD, "dateType");
+        writeCodelistValue(writer, publication);
+        writer.writeEndElement(); // dateType
+        writer.writeEndElement(); // CI_Date
+        writer.writeEndElement(); // date
+        writer.writeEndElement(); // CI_Citation
+        writer.writeEndElement(); // thesaurusName
+        writer.writeEndElement(); // MD_Keywords
+        writer.writeEndElement(); // descriptiveKeywords
+      }
     }
   }
 

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/GeneratorUtils.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/GeneratorUtils.java
@@ -10,6 +10,8 @@ import javax.xml.stream.XMLStreamWriter;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
 
 import static de.terrestris.mde.mde_backend.model.json.codelists.CI_OnLineFunctionCode.information;
 import static de.terrestris.mde.mde_backend.model.json.codelists.MD_CharacterSetCode.utf8;
@@ -19,6 +21,52 @@ import static de.terrestris.utils.xml.MetadataNamespaceUtils.*;
 import static de.terrestris.utils.xml.XmlUtils.writeSimpleElement;
 
 public class GeneratorUtils {
+
+  public static final Map<String, JsonIsoMetadata.InspireTheme> INSPIRE_THEME_MAP;
+
+  public static final Map<JsonIsoMetadata.InspireTheme, String> INSPIRE_THEME_KEYWORD_MAP;
+
+  static {
+    INSPIRE_THEME_MAP = new HashMap<>();
+    INSPIRE_THEME_MAP.put("Atmosphärische Bedingungen", JsonIsoMetadata.InspireTheme.AC);
+    INSPIRE_THEME_MAP.put("Adressen", JsonIsoMetadata.InspireTheme.AD);
+    INSPIRE_THEME_MAP.put("Landwirtschaftliche Anlagen und Aquakulturanlagen", JsonIsoMetadata.InspireTheme.AF);
+    INSPIRE_THEME_MAP.put("Bewirtschaftungsgebiete/Schutzgebiete/geregelte Gebiete und Berichterstattungseinheiten", JsonIsoMetadata.InspireTheme.AM);
+    INSPIRE_THEME_MAP.put("Verwaltungseinheiten", JsonIsoMetadata.InspireTheme.AU);
+    INSPIRE_THEME_MAP.put("Biogeografische Regionen", JsonIsoMetadata.InspireTheme.BR);
+    INSPIRE_THEME_MAP.put("Gebäude", JsonIsoMetadata.InspireTheme.BU);
+    INSPIRE_THEME_MAP.put("Flurstücke/Grundstücke (Katasterparzellen)", JsonIsoMetadata.InspireTheme.CP);
+    INSPIRE_THEME_MAP.put("Umweltüberwachung", JsonIsoMetadata.InspireTheme.EF);
+    INSPIRE_THEME_MAP.put("Höhe", JsonIsoMetadata.InspireTheme.EL);
+    INSPIRE_THEME_MAP.put("Energiequellen", JsonIsoMetadata.InspireTheme.ER);
+    INSPIRE_THEME_MAP.put("Geologie", JsonIsoMetadata.InspireTheme.GE);
+    INSPIRE_THEME_MAP.put("Geografische Gittersysteme", JsonIsoMetadata.InspireTheme.GG);
+    INSPIRE_THEME_MAP.put("Geografische Bezeichnungen", JsonIsoMetadata.InspireTheme.GN);
+    INSPIRE_THEME_MAP.put("Lebensräume und Biotope", JsonIsoMetadata.InspireTheme.HB);
+    INSPIRE_THEME_MAP.put("Gesundheit und Sicherheit", JsonIsoMetadata.InspireTheme.HH);
+    INSPIRE_THEME_MAP.put("Gewässernetz", JsonIsoMetadata.InspireTheme.HY);
+    INSPIRE_THEME_MAP.put("Bodenbedeckung", JsonIsoMetadata.InspireTheme.LC);
+    INSPIRE_THEME_MAP.put("Bodennutzung", JsonIsoMetadata.InspireTheme.LU);
+    INSPIRE_THEME_MAP.put("Meteorologisch-geografische Kennwerte", JsonIsoMetadata.InspireTheme.MF);
+    INSPIRE_THEME_MAP.put("Mineralische Bodenschätze", JsonIsoMetadata.InspireTheme.MR);
+    INSPIRE_THEME_MAP.put("Gebiete mit naturbedingten Risiken", JsonIsoMetadata.InspireTheme.NZ);
+    INSPIRE_THEME_MAP.put("Ozeanografisch-geografische Kennwerte", JsonIsoMetadata.InspireTheme.OF);
+    INSPIRE_THEME_MAP.put("Orthofotografie", JsonIsoMetadata.InspireTheme.OI);
+    INSPIRE_THEME_MAP.put("Verteilung der Bevölkerung — Demografie", JsonIsoMetadata.InspireTheme.PD);
+    INSPIRE_THEME_MAP.put("Produktions- und Industrieanlagen", JsonIsoMetadata.InspireTheme.PF);
+    INSPIRE_THEME_MAP.put("Schutzgebiete", JsonIsoMetadata.InspireTheme.PS);
+    INSPIRE_THEME_MAP.put("Koordinatenreferenzsysteme", JsonIsoMetadata.InspireTheme.RS);
+    INSPIRE_THEME_MAP.put("Verteilung der Arten", JsonIsoMetadata.InspireTheme.SD);
+    INSPIRE_THEME_MAP.put("Boden", JsonIsoMetadata.InspireTheme.SO);
+    INSPIRE_THEME_MAP.put("Meeresregionen", JsonIsoMetadata.InspireTheme.SR);
+    INSPIRE_THEME_MAP.put("Statistische Einheiten", JsonIsoMetadata.InspireTheme.SU);
+    INSPIRE_THEME_MAP.put("Verkehrsnetze", JsonIsoMetadata.InspireTheme.TN);
+    INSPIRE_THEME_MAP.put("Versorgungswirtschaft und staatliche Dienste", JsonIsoMetadata.InspireTheme.US);
+    INSPIRE_THEME_KEYWORD_MAP = new HashMap<>();
+    for (var e : INSPIRE_THEME_MAP.entrySet()) {
+      INSPIRE_THEME_KEYWORD_MAP.put(e.getValue(), e.getKey());
+    }
+  }
 
   protected static void writeLanguage(XMLStreamWriter writer) throws XMLStreamException {
     writer.writeStartElement(GMD, "language");

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/ServiceIsoGenerator.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/ServiceIsoGenerator.java
@@ -113,6 +113,7 @@ public class ServiceIsoGenerator {
       writePreview(writer, metadata.getPreview());
     }
     writeKeywords(writer, metadata);
+    writeInspireThemeKeywords(writer, metadata);
     switch (service.getServiceType()) {
       case WFS, ATOM -> writeServiceKeyword(writer, "infoFeatureAccessService");
       case WMS, WMTS -> writeServiceKeyword(writer, "infoMapAccessService");


### PR DESCRIPTION
Please note that this means that the INSPIRE themes won't be shown in the keywords but generated on the fly when generating the ISO keywords.

Also note that the data needs to be imported again else keywords might be generated twice.

@KaiVolland @dnlkoch Please review.