### PR TITLE
Add missing fields termsOfUseSource (26) and relatedTopics (36)

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/JsonClientMetadata.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/JsonClientMetadata.java
@@ -31,6 +31,8 @@ public class JsonClientMetadata {
 
   private Extent initialExtent;
 
+  private String relatedTopics;
+
   // Map of service.serviceIdentification and List of layers
   private Map<String, List<Layer>> layers;
 

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/JsonIsoMetadata.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/JsonIsoMetadata.java
@@ -144,4 +144,6 @@ public class JsonIsoMetadata implements FileIdentifier {
 
   private BigInteger termsOfUseId;
 
+  private String termsOfUseSource;
+
 }


### PR DESCRIPTION
This adds two more fields:

- `clientMetadata.termsOfUseSource` -> "Quelle-NB" (26)
- `isoMetadata.relatedTopics` -> "Verwandte Themen (MTK)" (36)