### PR TITLE
Default values on creation

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
@@ -99,7 +99,10 @@ public class MetadataCollectionService extends BaseMetadataService<MetadataColle
 
       metadataCollection.getIsoMetadata().setTitle(title);
       metadataCollection.getIsoMetadata().setIdentifier(metadataId);
+
+      // default values
       metadataCollection.getIsoMetadata().setMetadataProfile(MetadataProfile.ISO);
+      metadataCollection.getIsoMetadata().setCrs("http://www.opengis.net/def/crs/EPSG/0/25833");
 
       // User and role assignment. Set responsibleRole, ownerId, assignedUserId, teamMemberIds.
       Role roleToSet = null;

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.fge.jsonpatch.JsonPatchException;
+import de.terrestris.mde.mde_backend.enumeration.MetadataProfile;
 import de.terrestris.mde.mde_backend.enumeration.Role;
 import de.terrestris.mde.mde_backend.jpa.MetadataCollectionRepository;
 import de.terrestris.mde.mde_backend.model.MetadataCollection;
@@ -98,6 +99,7 @@ public class MetadataCollectionService extends BaseMetadataService<MetadataColle
 
       metadataCollection.getIsoMetadata().setTitle(title);
       metadataCollection.getIsoMetadata().setIdentifier(metadataId);
+      metadataCollection.getIsoMetadata().setMetadataProfile(MetadataProfile.ISO);
 
       // User and role assignment. Set responsibleRole, ownerId, assignedUserId, teamMemberIds.
       Role roleToSet = null;


### PR DESCRIPTION
This pull request introduces a default metadata profile and coordinate reference system (CRS) to the `MetadataCollectionService` class. These changes ensure that newly created metadata collections have consistent default values.

### Default Metadata Configuration:

* [`MetadataCollectionService.java`](diffhunk://#diff-e8f6945a4c3cc35a3b6200802a640573a0b718c8916531abbb47d982eadda2bfR103-R106): Added a default metadata profile (`MetadataProfile.ISO`) and a default CRS (`http://www.opengis.net/def/crs/EPSG/0/25833`) to the `create` method for new metadata collections. This ensures standardized defaults for metadata creation.
