### PR TITLE
Updates to clone metadata

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java
@@ -148,7 +148,7 @@ public class MetadataCollectionController
     try {
       String metadataId;
       if (creationData.getCloneMetadataId() != null) {
-        metadataId = service.create(creationData.getTitle(), creationData.getCloneMetadataId());
+        metadataId = service.clone(creationData.getTitle(), creationData.getCloneMetadataId());
       } else {
         metadataId = service.create(creationData.getTitle());
       }

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/MetadataCollection.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/MetadataCollection.java
@@ -22,7 +22,13 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordFie
 @Data
 public class MetadataCollection extends BaseMetadata {
 
-  @Column @Setter private String metadataId;
+  @Column
+  @Setter
+  private String metadataId;
+
+  @Column
+  @Setter
+  private String clonedFromId;
 
   @Formula("(iso_metadata->>'title')")
   private String title;
@@ -40,9 +46,15 @@ public class MetadataCollection extends BaseMetadata {
   @KeywordField(name = "team_member_sort", sortable = Sortable.YES)
   private Set<String> teamMemberIds;
 
-  @Column @Setter @KeywordField private String ownerId;
+  @Column
+  @Setter
+  @KeywordField
+  private String ownerId;
 
-  @Column @Setter @KeywordField private String assignedUserId;
+  @Column
+  @Setter
+  @KeywordField
+  private String assignedUserId;
 
   @Column
   @Setter

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/MetadataCollection.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/MetadataCollection.java
@@ -22,13 +22,9 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordFie
 @Data
 public class MetadataCollection extends BaseMetadata {
 
-  @Column
-  @Setter
-  private String metadataId;
+  @Column @Setter private String metadataId;
 
-  @Column
-  @Setter
-  private String clonedFromId;
+  @Column @Setter private String clonedFromId;
 
   @Formula("(iso_metadata->>'title')")
   private String title;
@@ -46,15 +42,9 @@ public class MetadataCollection extends BaseMetadata {
   @KeywordField(name = "team_member_sort", sortable = Sortable.YES)
   private Set<String> teamMemberIds;
 
-  @Column
-  @Setter
-  @KeywordField
-  private String ownerId;
+  @Column @Setter @KeywordField private String ownerId;
 
-  @Column
-  @Setter
-  @KeywordField
-  private String assignedUserId;
+  @Column @Setter @KeywordField private String assignedUserId;
 
   @Column
   @Setter

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
@@ -153,7 +153,7 @@ public class MetadataCollectionService
 
   @PreAuthorize("isAuthenticated()")
   @Transactional(isolation = Isolation.SERIALIZABLE)
-  public String create(String title, String cloneMetadataId) throws IOException {
+  public String clone(String title, String cloneMetadataId) throws IOException {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     String myKeycloakId =
         ((JwtAuthenticationToken) authentication).getTokenAttributes().get("sub").toString();
@@ -171,6 +171,8 @@ public class MetadataCollectionService
                     new NoSuchElementException(
                         "MetadataCollection not found for metadataId: " + cloneMetadataId));
 
+    metadataCollection.setClonedFromId(cloneMetadataId);
+
     JsonIsoMetadata clonedIsoData =
         objectMapper.readValue(
             objectMapper.writeValueAsString(originalMetadataCollection.getIsoMetadata()),
@@ -187,7 +189,33 @@ public class MetadataCollectionService
             objectMapper.writeValueAsString(originalMetadataCollection.getTechnicalMetadata()),
             new TypeReference<JsonTechnicalMetadata>() {});
     clonedIsoData.setIdentifier(metadataId);
+
+    // remove old values according to metadatenprofil-berlin.xlsx column "neuer Jahresstand".
+    // all checked properties are set to null / removed
     clonedIsoData.setFileIdentifier(null);
+    clonedIsoData.setDescription(null);
+    clonedIsoData.setInspireTheme(null);
+    clonedIsoData.setInspireAnnexVersion(null);
+    clonedIsoData.setCreated(null);
+    clonedIsoData.setPublished(null);
+    clonedIsoData.setModified(null);
+    clonedIsoData.setValidFrom(null);
+    clonedIsoData.setValidTo(null);
+    clonedIsoData.setScale(null);
+    clonedIsoData.setResolutions(null);
+    clonedIsoData.setPreview(null);
+    clonedIsoData.setTechnicalDescription(null);
+    clonedIsoData.setContentDescription(null);
+    clonedIsoData.setContentDescriptions(null);
+    clonedIsoData.setLineage(null);
+    clonedIsoData.setValid(false);
+    clonedIsoData.setServices(null);
+    clonedClientData.setRelatedTopics(null);
+    clonedClientData.setComments(null);
+    clonedTechnicalData.setDeliveredCrs(null);
+
+    // default values
+    metadataCollection.getIsoMetadata().setMetadataProfile(MetadataProfile.ISO);
 
     metadataCollection.setIsoMetadata(clonedIsoData);
     metadataCollection.setClientMetadata(clonedClientData);

--- a/mde-services/src/main/resources/db/migration/V2.0.6__cloned_from_id_column.sql
+++ b/mde-services/src/main/resources/db/migration/V2.0.6__cloned_from_id_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE metadata_collection ADD COLUMN cloned_from_id text;


### PR DESCRIPTION
This updates the cloning process ("Neuer Jahresstand") with two new features:

- Adds `clonedFromId` column
- Removes properties on clone (according to metadatenprofil-berlin_1.9.9.xslx)