### PR TITLE
Run `mvn clean` before publishing

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -7,7 +7,7 @@ plugins:
   - "@semantic-release/changelog"
   - - "@terrestris/maven-semantic-release"
     - mavenTarget: deploy
-      clean: false
+      clean: true
       updateSnapshotVersion: true
       processAllModules: true
   - - "@semantic-release/github"


### PR DESCRIPTION
This should ensure that no outdated artifacts are present in the `target` directories before publishing them.

Please note @KaiVolland @hwbllmnn.