### PR TITLE
Updates isTeamMember filter in specfication

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/specification/MetadataCollectionSpecification.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/specification/MetadataCollectionSpecification.java
@@ -36,12 +36,9 @@ public class MetadataCollectionSpecification {
       }
 
       // Team-Member-Filter (reused in sortPriority)
-      Expression<Integer> arrayPos = cb.function(
-        "array_position",
-        Integer.class,
-        root.get("teamMemberIds"),
-        cb.literal(myKeycloakId)
-      );
+      Expression<Integer> arrayPos =
+          cb.function(
+              "array_position", Integer.class, root.get("teamMemberIds"), cb.literal(myKeycloakId));
       Expression<Boolean> isTeamMember = cb.greaterThan(arrayPos, 0);
 
       if (config.getIsTeamMember() != null) {

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/specification/MetadataCollectionSpecification.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/specification/MetadataCollectionSpecification.java
@@ -36,13 +36,14 @@ public class MetadataCollectionSpecification {
       }
 
       // Team-Member-Filter (reused in sortPriority)
-      Expression<Boolean> isTeamMember =
-          cb.isNotNull(
-              cb.function(
-                  "array_position",
-                  Integer.class,
-                  root.get("teamMemberIds"),
-                  cb.literal(myKeycloakId)));
+      Expression<Integer> arrayPos = cb.function(
+        "array_position",
+        Integer.class,
+        root.get("teamMemberIds"),
+        cb.literal(myKeycloakId)
+      );
+      Expression<Boolean> isTeamMember = cb.greaterThan(arrayPos, 0);
+
       if (config.getIsTeamMember() != null) {
         if (config.getIsTeamMember()) {
           predicates.add(cb.isTrue(isTeamMember));


### PR DESCRIPTION
This fixes the `isTeamMember` filter in the specification.

It modifies the `searchMetadata` method in `MetadataCollectionSpecification` to improve the logic for determining team membership. The key change replaces the use of `cb.isNotNull` with a more robust check using `array_position` and `cb.greaterThan`.
