### PR TITLE
Update checks in deleteMetadata

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/PublicationService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/PublicationService.java
@@ -342,7 +342,8 @@ public class PublicationService {
         throw new ResponseStatusException(CONFLICT);
       }
 
-      // Editor can only delete metadata collections that are owned by them or where they are team members
+      // Editor can only delete metadata collections that are owned by them or where they are team
+      // members
       var isOwner = ownerId != null && ownerId.equals(userId);
       var isTeamMember = teamMemberIds != null && teamMemberIds.contains(userId);
       if (!isOwner && !isTeamMember) {

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/PublicationService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/PublicationService.java
@@ -328,17 +328,24 @@ public class PublicationService {
         metadataCollectionRepository
             .findByMetadataId(metadataId)
             .orElseThrow(() -> new ResponseStatusException(NOT_FOUND));
-    if (metadataCollection.getAssignedUserId() != null) {
-      throw new ResponseStatusException(CONFLICT);
-    }
+
+    var userId = auth.getName();
+
+    // Admin can always delete metadata collections
     if (!auth.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_MDEADMINISTRATOR"))) {
-      var userId = auth.getName();
-      if (metadataCollection.getOwnerId() == null
-          || metadataCollection.getTeamMemberIds() == null) {
+      var assignedUserId = metadataCollection.getAssignedUserId();
+      var ownerId = metadataCollection.getOwnerId();
+      var teamMemberIds = metadataCollection.getTeamMemberIds();
+
+      // Editor can only delete metadata collections that are assigned to them
+      if (assignedUserId != null && !assignedUserId.equals(userId)) {
         throw new ResponseStatusException(CONFLICT);
       }
-      if (!metadataCollection.getOwnerId().equals(userId)
-          && !metadataCollection.getTeamMemberIds().contains(userId)) {
+
+      // Editor can only delete metadata collections that are owned by them or where they are team members
+      var isOwner = ownerId != null && ownerId.equals(userId);
+      var isTeamMember = teamMemberIds != null && teamMemberIds.contains(userId);
+      if (!isOwner && !isTeamMember) {
         throw new ResponseStatusException(CONFLICT);
       }
     }


### PR DESCRIPTION
This updates the checks in the `deleteMetadata` method of the PublicationService. It now implements the following rules:

- Admin can always delete metadata collections
- Editor can only delete metadata collections that are assigned to them
- Editor can only delete metadata collections that are owned by them or where they are team members