### PR TITLE
Add null check for service short description

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/ServiceIsoGenerator.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/ServiceIsoGenerator.java
@@ -129,7 +129,9 @@ public class ServiceIsoGenerator {
     writer.writeEndElement(); // CI_Citation
     writer.writeEndElement(); // citation
     writer.writeStartElement(GMD, "abstract");
-    writeSimpleElement(writer, GCO, "CharacterString", service.getShortDescription());
+    if (service.getShortDescription() != null) {
+      writeSimpleElement(writer, GCO, "CharacterString", service.getShortDescription());
+    }
     writer.writeEndElement(); // abstract
     if (metadata.getPointsOfContact() != null) {
       for (var contact : metadata.getPointsOfContact()) {


### PR DESCRIPTION
Add a null check to prevent potential null pointer exceptions when accessing the service's short description.