### PR TITLE
Add null check for service type in getAutomaticKeywords method

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/DatasetIsoGenerator.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/DatasetIsoGenerator.java
@@ -321,6 +321,9 @@ public class DatasetIsoGenerator {
     }
     if (isoMetadata.getServices() != null) {
       for (var service : isoMetadata.getServices()) {
+        if (service.getServiceType() == null) {
+          continue;
+        }
         switch (service.getServiceType()) {
           case WFS, ATOM -> {
             if (!list.contains("Sachdaten")) {


### PR DESCRIPTION
Introduce a null check for the service type to prevent potential NullPointerExceptions when processing services in the getAutomaticKeywords method.