### PR TITLE
Adapt PreAuthorize for assignUser method

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
@@ -318,8 +318,10 @@ public class MetadataCollectionService
     return repository.save(metadataCollection);
   }
 
-  @PreAuthorize(
-      "hasRole('ROLE_MDEADMINISTRATOR') or hasRole('ROLE_MDEEDITOR') or hasRole('ROLE_MDEQUALITYASSURANCE')")
+  // TODO: we should add permission checks that reflect the frontend behavior
+  //  (compare showAssignAction in MetadataCard.svelte).
+  //  We may also want to ensure that MdeDataOwner can only assign themselves
+  @PreAuthorize("isAuthenticated()")
   @Transactional(isolation = Isolation.SERIALIZABLE)
   public void assignUser(String metadataId, String userId) {
     MetadataCollection metadataCollection =


### PR DESCRIPTION
Update the authorization check for the assignUser method to ensure that only authenticated users can access it, while noting the need for further permission checks to align with frontend behavior.