### PR TITLE
Add endpoint to start mass publication

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/controller/MetadataCollectionController.java
@@ -754,4 +754,38 @@ public class MetadataCollectionController
           e);
     }
   }
+
+  @Operation(
+      summary = "Publishes all metadata collections in the catalog (Geonetwork)",
+      description = "Publishes all metadata collections in the catalog (Geonetwork).",
+      security = {@SecurityRequirement(name = "Bearer Authentication")})
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Ok: The metadata was successfully published"),
+        @ApiResponse(
+            responseCode = "500",
+            description =
+                "Internal Server Error: Something internal went wrong while publishing the metadata",
+            content = @Content)
+      })
+  @ResponseStatus(HttpStatus.OK)
+  @PostMapping(value = "/publishall", produces = "application/json")
+  public ResponseEntity<String> publishAllMetadata() {
+    try {
+      publicationService.publishAllMetadata();
+
+      return new ResponseEntity<>(OK);
+    } catch (Exception e) {
+      log.error("Error while publishing all metadata: {}", e.getMessage());
+      log.trace("Full stack trace: ", e);
+
+      throw new ResponseStatusException(
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          messageSource.getMessage(
+              "BASE_CONTROLLER.INTERNAL_SERVER_ERROR", null, LocaleContextHolder.getLocale()),
+          e);
+    }
+  }
 }

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/GeneratorUtils.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/GeneratorUtils.java
@@ -298,6 +298,9 @@ public class GeneratorUtils {
 
   protected static void writeCrs(XMLStreamWriter writer, JsonIsoMetadata metadata)
       throws XMLStreamException {
+    if (metadata.getCrs() == null) {
+      return;
+    }
     writer.writeStartElement(GMD, "referenceSystemInfo");
     writer.writeStartElement(GMD, "MD_ReferenceSystem");
     writer.writeStartElement(GMD, "referenceSystemIdentifier");
@@ -334,6 +337,9 @@ public class GeneratorUtils {
 
   protected static <T> void writeCodelistValue(XMLStreamWriter writer, T codeListValue)
       throws XMLStreamException {
+    if (codeListValue == null) {
+      return;
+    }
     writer.writeStartElement(GMD, codeListValue.getClass().getSimpleName());
     writer.writeAttribute(
         "codeList",

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/IsoGenerator.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/IsoGenerator.java
@@ -60,6 +60,9 @@ public class IsoGenerator {
   }
 
   public static String replaceValues(String text) {
+    if (text == null) {
+      return "";
+    }
     for (var entry : VALUES_MAP.entrySet()) {
       text = text.replace(entry.getKey(), entry.getValue());
     }


### PR DESCRIPTION
This is a special publication step to re-publish all metadata. This means that `Insert` transactions are enforced even if a `fileIdentifier` exists.

@KaiVolland @dnlkoch  Please review.