### PR TITLE
Always unassign user when assigning a role

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
@@ -431,13 +431,7 @@ public class MetadataCollectionService
     String assignedUserId = metadataCollection.getAssignedUserId();
 
     if (assignedUserId != null) {
-      List<RoleRepresentation> keycloakUserRoles = keycloakService.getRealmRoles(assignedUserId);
-      List<String> keycloakUserRoleNames =
-          keycloakUserRoles.stream().map(RoleRepresentation::getName).toList();
-
-      if (!keycloakUserRoleNames.contains(role)) {
-        this.unassignUser(metadataId);
-      }
+      this.unassignUser(metadataId);
     }
     if (metadataCollection.getStatus().equals(Status.PUBLISHED)) {
       metadataCollection.setStatus(Status.IN_EDIT);


### PR DESCRIPTION
Ensure that a user is always unassigned when a new role is assigned, streamlining the role assignment process.