### PR TITLE
Remove unneeded contents

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/DatasetIsoGenerator.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/DatasetIsoGenerator.java
@@ -436,17 +436,25 @@ public class DatasetIsoGenerator {
   }
 
   protected static String getServiceUrl(Service s) {
+    Service.ServiceType serviceType = s.getServiceType();
+
+    if (serviceType == null) {
+      log.warn("No service type defined for service: {}", s.getServiceIdentification());
+      return null;
+    }
+
     var capas =
         String.format(
-            "%s/services/%s/%s?request=GetCapabilities&service=%s",
+            "%s/services/%s/%s",
             METADATA_VARIABLES.getServiceUrl(),
-            s.getServiceType().toString().toLowerCase(),
-            s.getWorkspace(),
-            s.getServiceType());
-    if (s.getServiceType().equals(ATOM)) {
+            serviceType.toString().toLowerCase(),
+            s.getWorkspace());
+
+    if (serviceType.equals(ATOM)) {
       capas =
           String.format("%s/data/%s/atom/", METADATA_VARIABLES.getServiceUrl(), s.getWorkspace());
     }
+
     return capas;
   }
 

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/ServiceIsoGenerator.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/ServiceIsoGenerator.java
@@ -64,19 +64,6 @@ public class ServiceIsoGenerator {
     writer.writeStartElement(GMD, "linkage");
     writeSimpleElement(writer, GMD, "URL", getServiceUrl(service));
     writer.writeEndElement(); // linkage
-    writer.writeStartElement(GMD, "protocol");
-    writeSimpleElement(writer, GCO, "CharacterString", "WWW:LINK-1.0-http--link");
-    writer.writeEndElement(); // protocol
-    writer.writeStartElement(GMD, "description");
-    writer.writeStartElement(GMX, "Anchor");
-    writer.writeAttribute(
-        XLINK,
-        "href",
-        "http://inspire.ec.europa.eu/metadata-codelist/OnLineDescriptionCode/accessPoint");
-    writer.writeCharacters(
-        "http://inspire.ec.europa.eu/metadata-codelist/OnLineDescriptionCode/accessPoint");
-    writer.writeEndElement(); // Anchor
-    writer.writeEndElement(); // description
     writer.writeStartElement(GMD, "function");
     writeCodelistValue(writer, information);
     writer.writeEndElement(); // function


### PR DESCRIPTION
This removes the `gmd:protocol` and `gmd:description` elements from the ISO service metadata and also removes the query parameters from the service urls.

Please review @KaiVolland.