### PR TITLE
Set same cache key as in test workflow

### DIFF
--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -32,8 +32,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2-
+          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-${{ runner.os }}-
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3


### PR DESCRIPTION
This way a cache created on `main` during the release workflow could potentially be reused from pull requests against it.

Please note @KaiVolland.