### PR TITLE
Add default value for deliveredCrs

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
@@ -88,6 +88,7 @@ public class MetadataCollectionService
     // default values
     metadataCollection.getIsoMetadata().setMetadataProfile(MetadataProfile.ISO);
     metadataCollection.getIsoMetadata().setCrs("http://www.opengis.net/def/crs/EPSG/0/25833");
+    metadataCollection.getTechnicalMetadata().setDeliveredCrs("25833");
 
     // User and role assignment. Set responsibleRole, ownerId, assignedUserId, teamMemberIds.
     Role roleToSet = null;


### PR DESCRIPTION
Set a default value for deliveredCrs in the technical metadata during the creation process.