### PR TITLE
Add shortDescription to FeatureType

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/FeatureType.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/FeatureType.java
@@ -20,4 +20,6 @@ public class FeatureType {
   @Nullable private String name;
 
   @Nullable private String title;
+
+  @Nullable private String shortDescription;
 }


### PR DESCRIPTION
Introduce a new field, shortDescription, to the FeatureType class to provide a brief overview of the feature.

Relies on https://github.com/gdi-be/mde-client/pull/169