### PR TITLE
Remove FilterType from ColumnInfo

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/ColumnInfo.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/json/ColumnInfo.java
@@ -14,14 +14,6 @@ import org.springframework.lang.Nullable;
 @AllArgsConstructor
 public class ColumnInfo {
 
-  public enum FilterType {
-    SelectBox,
-    CatalogBox,
-    DoubleEditOrderField,
-    EditField,
-    EditOrderField
-  }
-
   public enum ColumnType {
     BigDecimal,
     Date,
@@ -41,6 +33,4 @@ public class ColumnInfo {
   @Nullable private String alias;
 
   @Nullable private ColumnType type;
-
-  @Nullable private FilterType filterType;
 }


### PR DESCRIPTION
Eliminate the FilterType enum from the ColumnInfo class to simplify the code structure.

:exclamation: This requires a reimport or deletion of all existing filterType entries.