### PR TITLE
Init user cleanup scheduler

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/event/usercleanup/UserCleanupEvent.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/event/usercleanup/UserCleanupEvent.java
@@ -1,0 +1,11 @@
+package de.terrestris.mde.mde_backend.event.usercleanup;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class UserCleanupEvent extends ApplicationEvent {
+  public UserCleanupEvent(Object source) {
+    super(source);
+  }
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/event/usercleanup/UserCleanupEventListener.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/event/usercleanup/UserCleanupEventListener.java
@@ -1,0 +1,28 @@
+package de.terrestris.mde.mde_backend.event.usercleanup;
+
+import de.terrestris.mde.mde_backend.service.UserCleanupService;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Log4j2
+public class UserCleanupEventListener implements ApplicationListener<UserCleanupEvent> {
+
+  @Autowired private UserCleanupService userCleanupService;
+
+  @Override
+  public void onApplicationEvent(UserCleanupEvent event) {
+    try {
+      log.trace("Received a user cleanup event, starting cleanup task in background");
+
+      userCleanupService.runUserCleanup();
+
+      log.trace("Successfully started the cleanup task.");
+    } catch (Exception e) {
+      log.error("Error while starting the user cleanup task: {}", e.getMessage());
+      log.trace("Full stack trace: ", e);
+    }
+  }
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/event/usercleanup/UserCleanupEventPublisher.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/event/usercleanup/UserCleanupEventPublisher.java
@@ -1,0 +1,26 @@
+package de.terrestris.mde.mde_backend.event.usercleanup;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@Log4j2
+public class UserCleanupEventPublisher {
+
+  @Autowired private ApplicationEventPublisher applicationEventPublisher;
+
+  public void publish() {
+    try {
+      log.trace("Publishing a user cleanup event.");
+
+      applicationEventPublisher.publishEvent(new UserCleanupEvent(this));
+
+      log.trace("Successfully published a user cleanup event.");
+    } catch (Exception e) {
+      log.error("Error while publishing a user cleanup event: {}", e.getMessage());
+      log.trace("Full stack trace: ", e);
+    }
+  }
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/UserDetails.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/model/dto/UserDetails.java
@@ -7,6 +7,8 @@ import lombok.Data;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class UserDetails {
 
+  private String id;
+
   private String organisation;
 
   private String firstName;

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/properties/UserCleanupSchedulerProperties.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/properties/UserCleanupSchedulerProperties.java
@@ -1,0 +1,15 @@
+package de.terrestris.mde.mde_backend.properties;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@Configuration
+@ConfigurationProperties(prefix = "usercleanup")
+public class UserCleanupSchedulerProperties {
+  private Boolean enabled;
+  private String cleanupCron;
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/schedule/UserCleanupScheduler.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/schedule/UserCleanupScheduler.java
@@ -1,0 +1,22 @@
+package de.terrestris.mde.mde_backend.schedule;
+
+import de.terrestris.mde.mde_backend.event.usercleanup.UserCleanupEventPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnExpression("${usercleanup.enabled:false}")
+public class UserCleanupScheduler {
+
+  @Autowired private final UserCleanupEventPublisher userCleanupEventPublisher;
+
+  // Default: every weekday at 0 am
+  @Scheduled(cron = "${usercleanup.cleanup-cron:0 0 0 ? * MON-FRI}")
+  public void publishUserCleanup() {
+    userCleanupEventPublisher.publish();
+  }
+}

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/KeycloakService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/KeycloakService.java
@@ -2,12 +2,14 @@ package de.terrestris.mde.mde_backend.service;
 
 import de.terrestris.mde.mde_backend.model.dto.UserDetails;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import lombok.extern.log4j.Log4j2;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.admin.client.resource.UsersResource;
 import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -15,6 +17,9 @@ import org.springframework.stereotype.Service;
 @Service
 @Log4j2
 public class KeycloakService {
+
+  /** Number of users fetched per page when listing all Keycloak users. */
+  private static final int KEYCLOAK_USER_PAGE_SIZE = 100;
 
   @Autowired protected RealmResource keycloakRealm;
 
@@ -57,13 +62,50 @@ public class KeycloakService {
   public UserDetails getUserDetails(String userId) {
     var userResource = this.getUserResource(userId);
     var user = userResource.toRepresentation();
+    return mapToUserDetails(user);
+  }
+
+  /**
+   * Returns <em>all</em> users registered in the Keycloak realm.
+   *
+   * <p>The Keycloak Admin REST API caps a single {@code users().list()} call at 100 results by
+   * default. This method works around that limitation by iterating through pages of {@value
+   * #KEYCLOAK_USER_PAGE_SIZE} users until an empty page is returned, collecting every user across
+   * all pages before mapping them to {@link UserDetails}.
+   *
+   * @return list of all users in the realm; never {@code null}
+   */
+  @PreAuthorize("hasRole('ADMIN')")
+  public List<UserDetails> getAllUsers() {
+    List<UserDetails> allUsers = new ArrayList<>();
+    int first = 0;
+
+    while (true) {
+      List<UserRepresentation> page = keycloakRealm.users().list(first, KEYCLOAK_USER_PAGE_SIZE);
+      if (page.isEmpty()) {
+        break;
+      }
+      page.stream().map(this::mapToUserDetails).forEach(allUsers::add);
+      first += page.size();
+      if (page.size() < KEYCLOAK_USER_PAGE_SIZE) {
+        break;
+      }
+    }
+
+    log.debug("Retrieved {} users from Keycloak", allUsers.size());
+
+    return allUsers;
+  }
+
+  private UserDetails mapToUserDetails(UserRepresentation user) {
     var attributes = user.getAttributes();
     var details = new UserDetails();
 
     if (attributes == null) {
-      attributes = java.util.Collections.emptyMap();
+      attributes = Collections.emptyMap();
     }
 
+    details.setId(user.getId());
     details.setStreet(attributes.getOrDefault("streetAddress", List.of("")).getFirst());
     details.setCity(attributes.getOrDefault("city", List.of("")).getFirst());
     details.setPhone(attributes.getOrDefault("telephoneNumber", List.of("")).getFirst());

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/UserCleanupService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/UserCleanupService.java
@@ -1,0 +1,271 @@
+package de.terrestris.mde.mde_backend.service;
+
+import de.terrestris.mde.mde_backend.jpa.MetadataCollectionRepository;
+import de.terrestris.mde.mde_backend.model.MetadataCollection;
+import de.terrestris.mde.mde_backend.model.dto.UserDetails;
+import de.terrestris.mde.mde_backend.thread.TrackedTask;
+import de.terrestris.mde.mde_backend.thread.TrackingExecutorService;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.stereotype.Component;
+
+/**
+ * Service responsible for cleaning up stale Keycloak user references from {@link
+ * MetadataCollection} entities.
+ *
+ * <p>On each run it fetches the current list of users from Keycloak and iterates over all {@link
+ * MetadataCollection} records in batches of {@link #COLLECTIONS_BATCH_SIZE}. Any reference to a
+ * user id that no longer exists in Keycloak (owner, assigned user, or team member) is removed from
+ * the collection and persisted. A structured summary is written to the log at the end of each run.
+ *
+ * <p>The cleanup is submitted to the {@link TrackingExecutorService} thread pool so it runs
+ * asynchronously and does not block the calling thread.
+ */
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class UserCleanupService {
+
+  public static final Integer COLLECTIONS_BATCH_SIZE = 20;
+
+  @Autowired private KeycloakService keycloakService;
+
+  @Autowired private TrackingExecutorService trackingExecutorService;
+
+  @Autowired private MetadataCollectionRepository metadataCollectionRepository;
+
+  /**
+   * Holds all user-reference changes that were applied to a single {@link MetadataCollection}
+   * during one cleanup run.
+   *
+   * @param collectionId the database id of the affected {@link MetadataCollection}
+   * @param removedOwnerId the owner id that was removed, or {@code null} if the owner was still
+   *     present in Keycloak
+   * @param removedAssignedUserId the assigned-user id that was removed, or {@code null} if the
+   *     assigned user was still present in Keycloak
+   * @param removedTeamMemberIds list of team-member ids that were removed; empty if no team members
+   *     had to be removed
+   */
+  record CollectionCleanupRecord(
+      BigInteger collectionId,
+      String removedOwnerId,
+      String removedAssignedUserId,
+      List<String> removedTeamMemberIds) {
+
+    /**
+     * Returns {@code true} if at least one user reference was removed from the collection.
+     *
+     * @return {@code true} when the record represents actual changes, {@code false} otherwise
+     */
+    boolean hasChanges() {
+      return removedOwnerId != null
+          || removedAssignedUserId != null
+          || !removedTeamMemberIds.isEmpty();
+    }
+  }
+
+  /**
+   * Submits a user-cleanup task to the background thread pool.
+   *
+   * <p>The task:
+   *
+   * <ol>
+   *   <li>Creates a synthetic Spring {@link SecurityContext} with {@code ROLE_ADMIN} so that
+   *       secured service methods can be called without an active HTTP request.
+   *   <li>Retrieves the full list of users currently registered in Keycloak.
+   *   <li>Iterates over all {@link MetadataCollection} records in pages of {@link
+   *       #COLLECTIONS_BATCH_SIZE} and removes any user id that is no longer present in Keycloak.
+   *   <li>Writes a structured summary to the log via {@link #logSummary}.
+   * </ol>
+   *
+   * <p>Errors during execution are caught and logged; the security context is always cleared in a
+   * {@code finally} block to prevent context leaks.
+   */
+  public void runUserCleanup() {
+    // Submit cleanup task to thread pool to run in background
+    TrackedTask cleanupTask =
+        new TrackedTask(
+            "user-cleanup-" + System.currentTimeMillis(),
+            () -> {
+              try {
+                // Create a synthetic security context with ADMIN role for system-level operations.
+                SecurityContext context = new SecurityContextImpl();
+                UsernamePasswordAuthenticationToken adminAuth =
+                    new UsernamePasswordAuthenticationToken(
+                        "system", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+                context.setAuthentication(adminAuth);
+                SecurityContextHolder.setContext(context);
+
+                List<UserDetails> keycloakUsers = keycloakService.getAllUsers();
+                log.trace("Retrieved {} users from Keycloak", keycloakUsers.size());
+
+                if (keycloakUsers.isEmpty()) {
+                  throw new Exception("No users found in Keycloak.");
+                }
+
+                List<CollectionCleanupRecord> changedRecords = new ArrayList<>();
+
+                Page<MetadataCollection> collectionsPage =
+                    metadataCollectionRepository.findAll(PageRequest.of(0, COLLECTIONS_BATCH_SIZE));
+                long totalCollections = collectionsPage.getTotalElements();
+
+                log.trace(
+                    "Retrieved {} metadata collections – removing all Keycloak user ids "
+                        + "that are no longer present",
+                    totalCollections);
+
+                collectionsPage
+                    .getContent()
+                    .forEach(mc -> removeUser(mc, keycloakUsers).ifPresent(changedRecords::add));
+
+                while (collectionsPage.hasNext()) {
+                  collectionsPage =
+                      metadataCollectionRepository.findAll(collectionsPage.nextPageable());
+                  collectionsPage
+                      .getContent()
+                      .forEach(mc -> removeUser(mc, keycloakUsers).ifPresent(changedRecords::add));
+                }
+
+                logSummary(totalCollections, changedRecords);
+              } catch (Exception e) {
+                log.error("Error during user cleanup: {}", e.getMessage());
+                log.trace("Full stack trace:", e);
+              } finally {
+                SecurityContextHolder.clearContext();
+              }
+            });
+
+    trackingExecutorService.submit(cleanupTask);
+
+    log.trace("User cleanup task submitted to thread pool");
+  }
+
+  /**
+   * Writes a human-readable cleanup summary to the log at {@code INFO} level.
+   *
+   * <p>The summary contains:
+   *
+   * <ul>
+   *   <li>Total number of metadata collections that were checked.
+   *   <li>Number of collections that were actually modified.
+   *   <li>Per-collection breakdown of which user ids were removed (owner, assigned user, team
+   *       members).
+   * </ul>
+   *
+   * @param totalChecked total number of {@link MetadataCollection} records that were inspected
+   * @param changed list of {@link CollectionCleanupRecord} entries for every collection that had at
+   *     least one user reference removed
+   */
+  private void logSummary(long totalChecked, List<CollectionCleanupRecord> changed) {
+    log.info("=== User Cleanup Summary ===");
+    log.info("Metadata collections checked : {}", totalChecked);
+    log.info("Metadata collections modified: {}", changed.size());
+
+    if (changed.isEmpty()) {
+      log.info("No collections were modified.");
+    } else {
+      log.info("Modified collections:");
+      for (CollectionCleanupRecord record : changed) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("  Collection ID ").append(record.collectionId()).append(":");
+        if (record.removedOwnerId() != null) {
+          sb.append("\n    - owner removed          : ").append(record.removedOwnerId());
+        }
+        if (record.removedAssignedUserId() != null) {
+          sb.append("\n    - assigned user removed  : ").append(record.removedAssignedUserId());
+        }
+        if (!record.removedTeamMemberIds().isEmpty()) {
+          sb.append("\n    - team members removed   : ").append(record.removedTeamMemberIds());
+        }
+        log.info(sb.toString());
+      }
+    }
+    log.info("============================");
+  }
+
+  /**
+   * Checks a single {@link MetadataCollection} for stale Keycloak user references and removes any
+   * id that is no longer present in the provided list of active Keycloak users.
+   *
+   * <p>The following fields are checked:
+   *
+   * <ul>
+   *   <li>{@code ownerId} – set to {@code null} if the owner no longer exists.
+   *   <li>{@code assignedUserId} – set to {@code null} if the assigned user no longer exists.
+   *   <li>{@code teamMemberIds} – all ids of former Keycloak users are removed from the set.
+   * </ul>
+   *
+   * <p>If any change was made the collection is persisted immediately and a {@link
+   * CollectionCleanupRecord} capturing the removed ids is returned. If no ids were stale, {@link
+   * Optional#empty()} is returned and no database write occurs.
+   *
+   * @param metadataCollection the {@link MetadataCollection} to inspect and potentially update
+   * @param keycloakUsers the current list of all users registered in Keycloak
+   * @return an {@link Optional} containing a {@link CollectionCleanupRecord} with the removed ids
+   *     if any changes were made, or {@link Optional#empty()} if the collection was clean
+   */
+  private Optional<CollectionCleanupRecord> removeUser(
+      MetadataCollection metadataCollection, List<UserDetails> keycloakUsers) {
+
+    log.trace("Checking MetadataCollection ID {}", metadataCollection.getId());
+
+    String ownerId = metadataCollection.getOwnerId();
+    String assignedUserId = metadataCollection.getAssignedUserId();
+    Set<String> teamMemberIds = metadataCollection.getTeamMemberIds();
+
+    String removedOwnerId = null;
+    String removedAssignedUserId = null;
+    List<String> removedTeamMemberIds = new ArrayList<>();
+
+    // Check if ownerId exists in Keycloak
+    if (ownerId != null && keycloakUsers.stream().noneMatch(u -> u.getId().equals(ownerId))) {
+      removedOwnerId = ownerId;
+      metadataCollection.setOwnerId(null);
+    }
+
+    // Check if assignedUserId exists in Keycloak
+    if (assignedUserId != null
+        && keycloakUsers.stream().noneMatch(u -> u.getId().equals(assignedUserId))) {
+      removedAssignedUserId = assignedUserId;
+      metadataCollection.setAssignedUserId(null);
+    }
+
+    // Check teamMemberIds
+    if (teamMemberIds != null) {
+      teamMemberIds.forEach(
+          teamMemberId -> {
+            if (keycloakUsers.stream().noneMatch(u -> u.getId().equals(teamMemberId))) {
+              removedTeamMemberIds.add(teamMemberId);
+            }
+          });
+      teamMemberIds.removeIf(removedTeamMemberIds::contains);
+    }
+
+    CollectionCleanupRecord record =
+        new CollectionCleanupRecord(
+            metadataCollection.getId(),
+            removedOwnerId,
+            removedAssignedUserId,
+            removedTeamMemberIds);
+
+    if (record.hasChanges()) {
+      metadataCollectionRepository.save(metadataCollection);
+      return Optional.of(record);
+    }
+
+    return Optional.empty();
+  }
+}

--- a/mde-services/src/main/resources/application.properties
+++ b/mde-services/src/main/resources/application.properties
@@ -15,3 +15,6 @@ keycloak.server-url=https://${KEYCLOAK_HOST:shogun-keycloak}/auth
 keycloak.client-secret=${KEYCLOAK_CLIENT_SECRET}
 keycloak.realm=${KEYCLOAK_REALM}
 keycloak.client-id=${KEYCLOAK_CLIENT_ID}
+
+usercleanup.enabled=${CLEANUP_USERS_ENABLED:false}
+usercleanup.cleanup-cron=${CLEANUP_USERS_CRON:0 0 0 ? * MON-FRI}

--- a/mde-services/src/test/java/de/terrestris/mde/mde_backend/service/KeycloakServiceTest.java
+++ b/mde-services/src/test/java/de/terrestris/mde/mde_backend/service/KeycloakServiceTest.java
@@ -1,0 +1,136 @@
+package de.terrestris.mde.mde_backend.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import de.terrestris.mde.mde_backend.model.dto.UserDetails;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.UsersResource;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class KeycloakServiceTest {
+
+  @Mock private RealmResource keycloakRealm;
+
+  @Mock private UsersResource usersResource;
+
+  @InjectMocks private KeycloakService keycloakService;
+
+  @BeforeEach
+  void setUp() {
+    when(keycloakRealm.users()).thenReturn(usersResource);
+  }
+
+  @Test
+  void testGetAllUsersEmpty() {
+    when(usersResource.list(0, 100)).thenReturn(new ArrayList<>());
+
+    List<UserDetails> result = keycloakService.getAllUsers();
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+    verify(usersResource).list(0, 100);
+  }
+
+  @Test
+  void testGetAllUsersSinglePageLessThan100() {
+    List<UserRepresentation> page1 = createUserRepresentations(50);
+    when(usersResource.list(0, 100)).thenReturn(page1);
+
+    List<UserDetails> result = keycloakService.getAllUsers();
+
+    assertNotNull(result);
+    assertEquals(50, result.size());
+    verify(usersResource).list(0, 100);
+    verify(usersResource, times(1)).list(anyInt(), anyInt());
+  }
+
+  @Test
+  void testGetAllUsersExactly100() {
+    List<UserRepresentation> page1 = createUserRepresentations(100);
+    when(usersResource.list(0, 100)).thenReturn(page1);
+
+    List<UserDetails> result = keycloakService.getAllUsers();
+
+    assertNotNull(result);
+    assertEquals(100, result.size());
+    // Should detect full page and stop (no second call)
+    verify(usersResource).list(0, 100);
+  }
+
+  @Test
+  void testGetAllUsersMultiplePages() {
+    List<UserRepresentation> page1 = createUserRepresentations(100);
+    List<UserRepresentation> page2 = createUserRepresentations(50);
+
+    when(usersResource.list(0, 100)).thenReturn(page1);
+    when(usersResource.list(100, 100)).thenReturn(page2);
+
+    List<UserDetails> result = keycloakService.getAllUsers();
+
+    assertNotNull(result);
+    assertEquals(150, result.size());
+    verify(usersResource, times(2)).list(anyInt(), anyInt());
+  }
+
+  @Test
+  void testGetAllUsersExactly200() {
+    List<UserRepresentation> page1 = createUserRepresentations(100);
+    List<UserRepresentation> page2 = createUserRepresentations(100);
+    List<UserRepresentation> page3 = new ArrayList<>(); // empty page
+
+    when(usersResource.list(0, 100)).thenReturn(page1);
+    when(usersResource.list(100, 100)).thenReturn(page2);
+    when(usersResource.list(200, 100)).thenReturn(page3);
+
+    List<UserDetails> result = keycloakService.getAllUsers();
+
+    assertNotNull(result);
+    assertEquals(200, result.size());
+    verify(usersResource).list(0, 100);
+    verify(usersResource).list(100, 100);
+    verify(usersResource).list(200, 100);
+  }
+
+  @Test
+  void testGetAllUsersMapping() {
+    UserRepresentation user1 = new UserRepresentation();
+    user1.setId("user-123");
+    user1.setFirstName("John");
+    user1.setLastName("Doe");
+    user1.setEmail("john@example.com");
+
+    when(usersResource.list(0, 100)).thenReturn(List.of(user1));
+
+    List<UserDetails> result = keycloakService.getAllUsers();
+
+    assertEquals(1, result.size());
+    UserDetails userDetails = result.getFirst();
+    assertEquals("user-123", userDetails.getId());
+    assertEquals("John", userDetails.getFirstName());
+    assertEquals("Doe", userDetails.getLastName());
+    assertEquals("john@example.com", userDetails.getEmail());
+  }
+
+  private List<UserRepresentation> createUserRepresentations(int count) {
+    List<UserRepresentation> users = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      UserRepresentation user = new UserRepresentation();
+      user.setId("user-" + i);
+      user.setFirstName("First" + i);
+      user.setLastName("Last" + i);
+      user.setEmail("user" + i + "@example.com");
+      users.add(user);
+    }
+    return users;
+  }
+}

--- a/mde-services/src/test/java/de/terrestris/mde/mde_backend/service/UserCleanupServiceTest.java
+++ b/mde-services/src/test/java/de/terrestris/mde/mde_backend/service/UserCleanupServiceTest.java
@@ -1,0 +1,175 @@
+package de.terrestris.mde.mde_backend.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import de.terrestris.mde.mde_backend.jpa.MetadataCollectionRepository;
+import de.terrestris.mde.mde_backend.model.MetadataCollection;
+import de.terrestris.mde.mde_backend.model.dto.UserDetails;
+import de.terrestris.mde.mde_backend.thread.TrackingExecutorService;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserCleanupServiceTest {
+
+  @Mock private MetadataCollectionRepository metadataCollectionRepository;
+
+  @Mock private TrackingExecutorService trackingExecutorService;
+
+  @InjectMocks private UserCleanupService userCleanupService;
+
+  private List<UserDetails> validUsers;
+
+  @BeforeEach
+  void setUp() {
+    UserDetails user1 = new UserDetails();
+    user1.setId("valid-user-1");
+    user1.setFirstName("Alice");
+
+    UserDetails user2 = new UserDetails();
+    user2.setId("valid-user-2");
+    user2.setFirstName("Bob");
+
+    validUsers = List.of(user1, user2);
+  }
+
+  @Test
+  void testRemoveUserNoChanges() {
+    MetadataCollection mc =
+        createMetadataCollection(
+            "valid-user-1", "valid-user-2", Set.of("valid-user-1", "valid-user-2"));
+
+    Optional<UserCleanupService.CollectionCleanupRecord> result = invokeRemoveUser(mc, validUsers);
+
+    assertTrue(result.isEmpty(), "No changes should be made when all users are valid");
+    verify(metadataCollectionRepository, never()).save(any());
+  }
+
+  @Test
+  void testRemoveUserOwnerRemoved() {
+    MetadataCollection mc =
+        createMetadataCollection("stale-owner", "valid-user-2", Set.of("valid-user-1"));
+
+    Optional<UserCleanupService.CollectionCleanupRecord> result = invokeRemoveUser(mc, validUsers);
+
+    assertTrue(result.isPresent());
+    UserCleanupService.CollectionCleanupRecord record = result.get();
+    assertEquals("stale-owner", record.removedOwnerId());
+    assertNull(record.removedAssignedUserId());
+    assertTrue(record.removedTeamMemberIds().isEmpty());
+    assertNull(mc.getOwnerId());
+    verify(metadataCollectionRepository).save(mc);
+  }
+
+  @Test
+  void testRemoveUserAssignedUserRemoved() {
+    MetadataCollection mc =
+        createMetadataCollection("valid-user-1", "stale-assigned", Set.of("valid-user-1"));
+
+    Optional<UserCleanupService.CollectionCleanupRecord> result = invokeRemoveUser(mc, validUsers);
+
+    assertTrue(result.isPresent());
+    UserCleanupService.CollectionCleanupRecord record = result.get();
+    assertNull(record.removedOwnerId());
+    assertEquals("stale-assigned", record.removedAssignedUserId());
+    assertTrue(record.removedTeamMemberIds().isEmpty());
+    assertNull(mc.getAssignedUserId());
+    verify(metadataCollectionRepository).save(mc);
+  }
+
+  @Test
+  void testRemoveUserTeamMembersRemoved() {
+    MetadataCollection mc =
+        createMetadataCollection(
+            "valid-user-1",
+            "valid-user-2",
+            Set.of("valid-user-1", "stale-member-1", "stale-member-2"));
+
+    Optional<UserCleanupService.CollectionCleanupRecord> result = invokeRemoveUser(mc, validUsers);
+
+    assertTrue(result.isPresent());
+    UserCleanupService.CollectionCleanupRecord record = result.get();
+    assertNull(record.removedOwnerId());
+    assertNull(record.removedAssignedUserId());
+    assertEquals(2, record.removedTeamMemberIds().size());
+    assertTrue(
+        record.removedTeamMemberIds().containsAll(List.of("stale-member-1", "stale-member-2")));
+    assertEquals(1, mc.getTeamMemberIds().size());
+    assertTrue(mc.getTeamMemberIds().contains("valid-user-1"));
+    verify(metadataCollectionRepository).save(mc);
+  }
+
+  @Test
+  void testRemoveUserMultipleChanges() {
+    MetadataCollection mc =
+        createMetadataCollection(
+            "stale-owner",
+            "stale-assigned",
+            Set.of("stale-team-1", "valid-user-1", "stale-team-2"));
+
+    Optional<UserCleanupService.CollectionCleanupRecord> result = invokeRemoveUser(mc, validUsers);
+
+    assertTrue(result.isPresent());
+    UserCleanupService.CollectionCleanupRecord record = result.get();
+    assertEquals("stale-owner", record.removedOwnerId());
+    assertEquals("stale-assigned", record.removedAssignedUserId());
+    assertEquals(2, record.removedTeamMemberIds().size());
+    assertTrue(record.hasChanges());
+    verify(metadataCollectionRepository).save(mc);
+  }
+
+  @Test
+  void testRemoveUserNullTeamMembers() {
+    MetadataCollection mc = new MetadataCollection();
+    mc.setOwnerId("valid-user-1");
+    mc.setAssignedUserId("valid-user-2");
+    mc.setTeamMemberIds(null);
+
+    Optional<UserCleanupService.CollectionCleanupRecord> result = invokeRemoveUser(mc, validUsers);
+
+    assertTrue(result.isEmpty());
+    verify(metadataCollectionRepository, never()).save(any());
+  }
+
+  @Test
+  void testRunUserCleanupSubmitsTask() {
+    userCleanupService.runUserCleanup();
+
+    verify(trackingExecutorService).submit(any(Runnable.class));
+  }
+
+  private MetadataCollection createMetadataCollection(
+      String ownerId, String assignedUserId, Set<String> teamMemberIds) {
+    MetadataCollection mc = new MetadataCollection();
+    mc.setOwnerId(ownerId);
+    mc.setAssignedUserId(assignedUserId);
+    mc.setTeamMemberIds(new HashSet<>(teamMemberIds));
+    return mc;
+  }
+
+  private Optional<UserCleanupService.CollectionCleanupRecord> invokeRemoveUser(
+      MetadataCollection mc, List<UserDetails> users) {
+    try {
+      var method =
+          UserCleanupService.class.getDeclaredMethod(
+              "removeUser", MetadataCollection.class, List.class);
+      method.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      Optional<UserCleanupService.CollectionCleanupRecord> result =
+          (Optional<UserCleanupService.CollectionCleanupRecord>)
+              method.invoke(userCleanupService, mc, users);
+      return result;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to invoke removeUser method", e);
+    }
+  }
+}


### PR DESCRIPTION
This initializes the `UserCleanupScheduler` that can be used to remove non-existing users (identified by the Keycloak user's ID) from any `MetadataCollection`. In particular the user will be removed from the fields `owner_id`,` assigned_user_id` and `team_member_ids`. 

The cleanup process is implemented as scheduled task and it's possible to configure the behaviour of it with the following environment variables:

- `CLEANUP_USERS_ENABLED: true # default is to false`
- `CLEANUP_USERS_CRON: "0 0 0 ? * MON-FRI" # default is to once a weekday at 0 am`

After each run a summary of the cleanup process is written to the main log and looks as follows:

```bash
=== User Cleanup Summary ===
Metadata collections checked : 677
Metadata collections modified: 2
Modified collections:
  Collection ID 1798:
    - owner removed          : 9876
    - assigned user removed  : 1235
    - team members removed   : [1908]
  Collection ID 1797:
    - owner removed          : 5678
    - assigned user removed  : 1234
    - team members removed   : [1909]
============================
```

Please review @mholthausen.