### PR TITLE
Fix missing approved reset in metadata editing (#29971)

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
@@ -435,6 +435,7 @@ public class MetadataCollectionService
     }
     if (metadataCollection.getStatus().equals(Status.PUBLISHED)) {
       metadataCollection.setStatus(Status.IN_EDIT);
+      metadataCollection.setApproved(false);
     }
 
     repository.save(metadataCollection);
@@ -517,6 +518,7 @@ public class MetadataCollectionService
     }
     if (metadataCollection.getStatus().equals(Status.PUBLISHED)) {
       metadataCollection.setStatus(Status.IN_EDIT);
+      metadataCollection.setApproved(false);
     }
 
     metadataCollection.setResponsibleRole(Role.valueOf(role));
@@ -686,6 +688,7 @@ public class MetadataCollectionService
     if (metadataCollection.getStatus().equals(Status.PUBLISHED)) {
       metadataCollection.setStatus(Status.IN_EDIT);
     }
+    metadataCollection.setApproved(false);
 
     repository.save(metadataCollection);
 


### PR DESCRIPTION
See also [#29971](https://redmine.intranet.terrestris.de/issues/29971).

When updating published metadata (adding layers, assigning users/roles), the approval flag isn't reset to false, allowing unpublished metadata to be published without QA review.

This PR adds `metadataCollection.setApproved(false);` in three methods that change status to `IN_EDIT` to prevent unauthorized metadata publication without QA approval:

```java
assignUser()
assignRole()
updateLayers()
```
