### PR TITLE
Clear template specific metadata (#30041)

### DIFF
--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
@@ -191,6 +191,7 @@ public class MetadataCollectionService
 
     clonedTechnicalData.setDeliveredCrs(null);
     clonedTechnicalData.setLayerInfos(null);
+    clonedTechnicalData.setCategories(null);
 
     // default values
     metadataCollection.getIsoMetadata().setMetadataProfile(MetadataProfile.ISO);

--- a/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
+++ b/mde-services/src/main/java/de/terrestris/mde/mde_backend/service/MetadataCollectionService.java
@@ -184,9 +184,13 @@ public class MetadataCollectionService
     clonedIsoData.setLineage(null);
     clonedIsoData.setValid(false);
     clonedIsoData.setServices(null);
+
     clonedClientData.setRelatedTopics(null);
     clonedClientData.setComments(null);
+    clonedClientData.setLayers(null);
+
     clonedTechnicalData.setDeliveredCrs(null);
+    clonedTechnicalData.setLayerInfos(null);
 
     // default values
     metadataCollection.getIsoMetadata().setMetadataProfile(MetadataProfile.ISO);

--- a/mde-services/src/test/java/de/terrestris/mde/mde_backend/service/MetadataCollectionServiceTest.java
+++ b/mde-services/src/test/java/de/terrestris/mde/mde_backend/service/MetadataCollectionServiceTest.java
@@ -96,9 +96,9 @@ class MetadataCollectionServiceTest {
     assertNull(clone.getClientMetadata().getComments());
     assertNull(clone.getTechnicalMetadata().getLayerInfos());
     assertNull(clone.getTechnicalMetadata().getDeliveredCrs());
+    assertNull(clone.getTechnicalMetadata().getCategories());
     assertEquals(initialExtent, clone.getClientMetadata().getInitialExtent());
     assertEquals(databaseInfo, clone.getTechnicalMetadata().getDatabaseInfo());
-    assertEquals(categories, clone.getTechnicalMetadata().getCategories());
     assertEquals(descriptions, clone.getTechnicalMetadata().getDescriptions());
   }
 }

--- a/mde-services/src/test/java/de/terrestris/mde/mde_backend/service/MetadataCollectionServiceTest.java
+++ b/mde-services/src/test/java/de/terrestris/mde/mde_backend/service/MetadataCollectionServiceTest.java
@@ -1,0 +1,104 @@
+package de.terrestris.mde.mde_backend.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import de.terrestris.mde.mde_backend.jpa.MetadataCollectionRepository;
+import de.terrestris.mde.mde_backend.model.MetadataCollection;
+import de.terrestris.mde.mde_backend.model.json.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+class MetadataCollectionServiceTest {
+
+  @Mock private MetadataCollectionRepository repository;
+
+  @Mock private JwtAuthenticationToken authentication;
+
+  @Spy private ObjectMapper objectMapper = new ObjectMapper();
+
+  @InjectMocks private MetadataCollectionService metadataCollectionService;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(metadataCollectionService, "repository", repository);
+    when(authentication.getTokenAttributes()).thenReturn(Map.of("sub", "user-id"));
+    when(authentication.getAuthorities()).thenReturn(List.of());
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void testCloneClearsTemplateSpecificMetadata() throws Exception {
+    String sourceId = "source-id";
+    MetadataCollection source = new MetadataCollection(sourceId);
+
+    Extent initialExtent = new Extent("EPSG:25833", 1.0, 2.0, 3.0, 4.0);
+    source.getClientMetadata().setInitialExtent(initialExtent);
+    source.getClientMetadata().setLayers(Map.of("atom-service", List.of(new Layer())));
+    source.getClientMetadata().setRelatedTopics("related topics");
+    source.getClientMetadata().setComments(List.of(new Comment()));
+
+    DatabaseInfo databaseInfo =
+        new DatabaseInfo("driver", "jdbc:postgresql://database", List.of("table"));
+    List<Category> categories = List.of(new Category("title", "type", "url"));
+    List<String> descriptions = List.of("description");
+    source.getTechnicalMetadata().setDatabaseInfo(databaseInfo);
+    source.getTechnicalMetadata().setCategories(categories);
+    source.getTechnicalMetadata().setDescriptions(descriptions);
+    source.getTechnicalMetadata().setDeliveredCrs("25833");
+    source
+        .getTechnicalMetadata()
+        .setLayerInfos(List.of(new LayerInfo("atom-download", "workspace")));
+
+    AtomicReference<MetadataCollection> cloneReference = new AtomicReference<>();
+    when(repository.findByMetadataId(anyString()))
+        .thenAnswer(
+            invocation -> {
+              String metadataId = invocation.getArgument(0);
+              return sourceId.equals(metadataId)
+                  ? Optional.of(source)
+                  : Optional.ofNullable(cloneReference.get());
+            });
+    when(repository.save(any(MetadataCollection.class)))
+        .thenAnswer(
+            invocation -> {
+              MetadataCollection metadataCollection = invocation.getArgument(0);
+              cloneReference.set(metadataCollection);
+              return metadataCollection;
+            });
+
+    metadataCollectionService.clone("Cloned title", sourceId);
+
+    MetadataCollection clone = cloneReference.get();
+    assertNull(clone.getClientMetadata().getLayers());
+    assertNull(clone.getClientMetadata().getRelatedTopics());
+    assertNull(clone.getClientMetadata().getComments());
+    assertNull(clone.getTechnicalMetadata().getLayerInfos());
+    assertNull(clone.getTechnicalMetadata().getDeliveredCrs());
+    assertEquals(initialExtent, clone.getClientMetadata().getInitialExtent());
+    assertEquals(databaseInfo, clone.getTechnicalMetadata().getDatabaseInfo());
+    assertEquals(categories, clone.getTechnicalMetadata().getCategories());
+    assertEquals(descriptions, clone.getTechnicalMetadata().getDescriptions());
+  }
+}


### PR DESCRIPTION
See also [#30041](https://redmine.intranet.terrestris.de/issues/30041).

This PR clears `clientMetadata.layers` and `technicalMetadata.layerInfos` and `technicalMetadata.categories` when cloning a metadata record.

The following fields remain unchanged:

**clientMetadata**:
- `initialExtent`

**technicalMetadata**:
- `databaseInfo`
- `descriptions`

The existing cleanup of `relatedTopics`, `comments` and `deliveredCrs` remains unchanged.

A unit test verifies that template-specific metadata is cleared during cloning while unaffected fields are preserved.